### PR TITLE
Type-Ahead and "remember last X" searches

### DIFF
--- a/examples/search-with-prefs/src/app/app.component.html
+++ b/examples/search-with-prefs/src/app/app.component.html
@@ -11,9 +11,9 @@
   <div class="burger-handle" (click)="showPrefs=!showPrefs"><div class="hamburger"></div></div>
   <div class="prefs-container">
     <!-- start prefs service box -->
-    <!--<sz-preferences #prefsComponent
+    <sz-preferences #prefsComponent
     showControls="true"
-    ></sz-preferences>-->
+    ></sz-preferences>
     <!--  end prefs service box  -->
   </div>
 </div>

--- a/examples/search-with-prefs/src/app/app.component.html
+++ b/examples/search-with-prefs/src/app/app.component.html
@@ -11,16 +11,16 @@
   <div class="burger-handle" (click)="showPrefs=!showPrefs"><div class="hamburger"></div></div>
   <div class="prefs-container">
     <!-- start prefs service box -->
-    <sz-preferences #prefsComponent
+    <!--<sz-preferences #prefsComponent
     showControls="true"
-    ></sz-preferences>
+    ></sz-preferences>-->
     <!--  end prefs service box  -->
   </div>
 </div>
 
 <!-- start search box -->
 <div class="component-example">
-  <!--<sz-search
+  <sz-search
     #searchBox
     name="Elizabeth Jones"
     disableIdentifierOptions="SSN_LAST4"
@@ -28,14 +28,7 @@
     (resultsChange)="onSearchResults($event)"
     (resultsCleared)="onSearchResultsCleared($event)"
     (exception)="onSearchException($event)"
-    (parameterChange)="onSearchParameterChange($event)"></sz-search>-->
-  <sz-search-by-id #searchBox
-  [dataSource]="'COMPANIES'"
-  (parameterChange)="onSearchParameterChange($event)"
-  (exception)="onByIdException($event)"
-  (entityChange)="onEntityResult($event)"
-  (resultCleared)="onSearchResultsCleared($event)"
-  (resultChange)="onResultChange($event)"></sz-search-by-id>
+    (parameterChange)="onSearchParameterChange($event)"></sz-search>
 </div>
 <!-- end search box -->
 <!-- start search result for sz-search-by-id -->

--- a/examples/search-with-prefs/src/app/app.component.ts
+++ b/examples/search-with-prefs/src/app/app.component.ts
@@ -108,7 +108,6 @@ export class AppComponent implements AfterViewInit, OnDestroy {
     ).subscribe( (srprefs) => {
       this._prefsJSON = srprefs;
       this.savePrefsToLocalStorage();
-      // console.warn('consumer prefs change: ', srprefs);
     });
   }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -5855,10 +5855,6 @@
         "schema-utils": "^1.0.0"
       }
     },
-    "file-saver": {
-      "version": "github:eligrey/FileSaver.js#e865e37af9f9947ddcced76b549e27dc45c1cb2e",
-      "from": "github:eligrey/FileSaver.js#1.3.8"
-    },
     "filename-regex": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
@@ -6257,12 +6253,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -6277,17 +6275,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -6404,7 +6405,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -6416,6 +6418,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -6430,6 +6433,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -6437,12 +6441,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -6461,6 +6467,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -6541,7 +6548,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -6553,6 +6561,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -6674,6 +6683,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -8577,7 +8587,6 @@
       "integrity": "sha512-J9X76xnncMw+wIqb15HeWfPMqPwYxSpPY8yWPJ7rAZN/ZDzFkjCSZObryCyUe8zbrVRNiuCnIeQteCzMn7GnWw==",
       "requires": {
         "canvg": "1.5.3",
-        "file-saver": "github:eligrey/FileSaver.js#e865e37af9f9947ddcced76b549e27dc45c1cb2e",
         "html2canvas": "1.0.0-alpha.12",
         "omggif": "1.0.7",
         "promise-polyfill": "8.1.0",
@@ -8591,6 +8600,10 @@
           "requires": {
             "base64-arraybuffer": "^0.1.5"
           }
+        },
+        "file-saver": {
+          "version": "github:eligrey/FileSaver.js#e865e37af9f9947ddcced76b549e27dc45c1cb2e",
+          "from": "github:eligrey/FileSaver.js#e865e37af9f9947ddcced76b549e27dc45c1cb2e"
         },
         "html2canvas": {
           "version": "1.0.0-alpha.12",

--- a/src/lib/configuration/sz-preferences/sz-preferences.component.html
+++ b/src/lib/configuration/sz-preferences/sz-preferences.component.html
@@ -1,6 +1,6 @@
 <div *ngIf="showControls" class="sz-preferences">
     <div class="prefs-ui-lists">
-        <!-- start search form prefs
+        <!-- start search form prefs -->
         <div class="prefs-ui-column prefs-ui-column-search-form">
             <h4 class="title">Search</h4>
             <ul class="prefs-ui-column-inner">
@@ -17,7 +17,7 @@
                 </li>
             </ul>
         </div>
-         end search form prefs -->
+        <!-- end search form prefs -->
         <!-- start search results prefs -->
         <div class="prefs-ui-column prefs-ui-column-search-results">
             <h4 class="title">Search Results</h4>

--- a/src/lib/configuration/sz-preferences/sz-preferences.component.ts
+++ b/src/lib/configuration/sz-preferences/sz-preferences.component.ts
@@ -427,7 +427,7 @@ export class SzPreferencesComponent implements OnInit, OnDestroy {
 
   /** which fields to explicitly not show to the user */
   @Input() public editableBlacklist = {
-    searchForm: [],
+    searchForm: ['allowedTypeAttributes','searchHistory'],
     searchResults: ['truncateRecordsAt','linkToEmbeddedGraph','showEmbeddedGraph','openInNewTab'],
     entityDetail: ['openLinksInNewTab'],
     graph: ['dataSourceColors','openInNewTab','openInSidePanel']

--- a/src/lib/models/entity-search.ts
+++ b/src/lib/models/entity-search.ts
@@ -1,3 +1,10 @@
+/**
+ * A model of search parameters that can be sent to the
+ * api server.
+ *
+ * @export
+ * @interface SzEntitySearchParams
+ */
 export interface SzEntitySearchParams {
   "NAME_TYPE"?: string,
   "NAME_FIRST"?: string,

--- a/src/lib/models/entity-search.ts
+++ b/src/lib/models/entity-search.ts
@@ -3,7 +3,6 @@
  * api server.
  *
  * @export
- * @interface SzEntitySearchParams
  */
 export interface SzEntitySearchParams {
   "NAME_TYPE"?: string,

--- a/src/lib/models/folio.ts
+++ b/src/lib/models/folio.ts
@@ -1,26 +1,41 @@
 import { SzEntitySearchParams } from './entity-search';
 
 // -----------------------  start base folio classes -------------------------
-
+/**
+ * A abstract class representing a generic SzFolioItem.
+ */
 export abstract class SzFolioItem {
+  /** the name of the folio item */
   abstract name: string;
+  /** the data representing this folio item */
   abstract _data;
+  /** the data representing this folio item */
   public get data ()  {
     return this._data;
   }
+  /** the data representing this folio item */
   public set data (value: any) {
     this._data = value;
   }
 }
 
+/**
+ * A collection base class containing common
+ * properties and methods for interacting with a
+ * collection of SzFolioItem based items.
+ */
 export abstract class SzFolio {
+  /** the collection of SzFolioItem's */
   abstract items: SzFolioItem[] = [];
+  /** the name of the folio */
   public name: string;
 
+  /** add a  SzFolioItem to the "items" collection */
   public add( item: SzFolioItem ) {
     this.items.push( item );
   }
   // TODO: handle overloads
+  /** remove a SzFolioItem from "items" if it exists */
   public remove( item ) {
 
   }
@@ -29,8 +44,16 @@ export abstract class SzFolio {
 
 
 // -----------------------  start search form folios -------------------------
+/**
+ * a folio item representing a set of search parameters to save a set of
+ * search parameters in a folio.
+ * @export
+ * @class SzSearchParamsFolioItem
+ * @extends {SzFolioItem}
+ */
 export class SzSearchParamsFolioItem extends SzFolioItem {
   _data: SzEntitySearchParams;
+  /** if set the name should be used when displaying the item to the user */
   name: string;
 
   public get data (): SzEntitySearchParams {
@@ -46,8 +69,16 @@ export class SzSearchParamsFolioItem extends SzFolioItem {
   }
 }
 
+/**
+ * A folio representing a collection of searches
+ * @export
+ * @class SzSearchParamsFolio
+ * @extends {SzFolio}
+ */
 export class SzSearchParamsFolio extends SzFolio {
+  /** the search parameter sets */
   items: SzSearchParamsFolioItem[];
+  /** the name of the search set */
   name: string;
 
   constructor( items?: SzSearchParamsFolioItem[]) {
@@ -59,7 +90,14 @@ export class SzSearchParamsFolio extends SzFolio {
 }
 // -----------------------    end search form folios   -------------------------
 
-// ----------------------- start search history folios -------------------------
+/**
+ * A folio item specific to being used in the search history folio. It
+ * extends the SzSearchParamsFolioItem class.
+ *
+ * @export
+ * @class SzSearchHistoryFolioItem
+ * @extends {SzSearchParamsFolioItem}
+ */
 export class SzSearchHistoryFolioItem extends SzSearchParamsFolioItem {
   public get name(): string {
     let retVal;
@@ -72,10 +110,21 @@ export class SzSearchHistoryFolioItem extends SzSearchParamsFolioItem {
     super(data); // must call super()
   }
 }
-
+/**
+ * A specialized SzFolio class used for storing the user's search history.
+ *
+ * @export
+ * @class SzSearchHistoryFolio
+ * @extends {SzSearchParamsFolio}
+ */
 export class SzSearchHistoryFolio extends SzSearchParamsFolio {
+  /**
+   * the collection of search parameters used in the last X searches
+   */
   items: SzSearchHistoryFolioItem[];
+  /** hardcoded to 'Search History' */
   public name: string = 'Search History';
+  /** The number of searches back to store in the folio */
   public maxItems: number = 20;
 
   /** gets the history folio items in decending chronological order */
@@ -91,7 +140,9 @@ export class SzSearchHistoryFolio extends SzSearchParamsFolio {
     if (items) { this.items = items; }
     if (name) { this.name = name; }
   }
-
+  /**
+   * Add a new search parameter set to the stack
+   */
   public add( item: SzSearchHistoryFolioItem ) {
     this.items.push( item );
     if(this.maxItems && this.items.length > this.maxItems) {
@@ -100,7 +151,7 @@ export class SzSearchHistoryFolio extends SzSearchParamsFolio {
       console.warn('tempArr : ', this.items);
     }
   }
-
+  /** get a json representation model of this class and its items. */
   public toJSONObject(): {name?: string, items: any} {
     let _items = this.items.map( (item: SzSearchHistoryFolioItem) => {
       return item.data;
@@ -110,7 +161,8 @@ export class SzSearchHistoryFolio extends SzSearchParamsFolio {
       items: _items
     }
   }
-
+  /** set the folios properties via a json model. This is the same model that
+   * this.toJSONObject returns */
   public fromJSONObject(data: {name?: string, items: any}) {
     if(data && data.name) { this.name = data.name;}
     if(data && data.items && data.items.map) {
@@ -121,7 +173,13 @@ export class SzSearchHistoryFolio extends SzSearchParamsFolio {
       this.items = SzSearchHistoryFolio.FolioItemsFromJSON(data.items);
     }
   }
-
+  /**
+   * returns an array of "SzSearchHistoryFolio" that is created from the
+   * 'items' model that 'toJSONObject' returns.
+   * @static
+   * @param {[]} itemsJson
+   * @returns {SzSearchHistoryFolioItem[]}
+   */
   static FolioItemsFromJSON( itemsJson: [] ): SzSearchHistoryFolioItem[] {
     let _items = itemsJson.map( (item) => {
       return new SzSearchHistoryFolioItem( item );

--- a/src/lib/models/folio.ts
+++ b/src/lib/models/folio.ts
@@ -1,0 +1,50 @@
+import { SzEntitySearchParams } from './entity-search';
+
+export abstract class SzFolioItem {
+  abstract name: string;
+  abstract _data;
+  public get data () {
+    return this._data;
+  }
+  public set data (value: any) {
+    this._data = value;
+  }
+}
+
+export abstract class SzFolio {
+  abstract items: SzFolioItem[];
+  public name: string;
+
+  public add( item: SzFolioItem ) {
+    this.items.push( item );
+  }
+  // TODO: handle overloads
+  public remove( item ) {
+
+  }
+}
+
+
+export class SzSearchParamsFolioItem extends SzFolioItem {
+  _data: SzEntitySearchParams;
+  name: string;
+
+  constructor(name: string, data: SzEntitySearchParams) {
+    super(); // must call super()
+
+    this.data = data;
+    this.name = name;
+  }
+}
+
+export class SzSearchParamsFolio extends SzFolio {
+  items: SzSearchParamsFolioItem[];
+  name: string;
+
+  constructor(name: string, items?: SzSearchParamsFolioItem[]) {
+    super(); // must call super()
+
+    if (items) { this.items = items; }
+    this.name = name;
+  }
+}

--- a/src/lib/models/folio.ts
+++ b/src/lib/models/folio.ts
@@ -1,9 +1,11 @@
 import { SzEntitySearchParams } from './entity-search';
 
+// -----------------------  start base folio classes -------------------------
+
 export abstract class SzFolioItem {
   abstract name: string;
   abstract _data;
-  public get data () {
+  public get data ()  {
     return this._data;
   }
   public set data (value: any) {
@@ -12,7 +14,7 @@ export abstract class SzFolioItem {
 }
 
 export abstract class SzFolio {
-  abstract items: SzFolioItem[];
+  abstract items: SzFolioItem[] = [];
   public name: string;
 
   public add( item: SzFolioItem ) {
@@ -23,17 +25,24 @@ export abstract class SzFolio {
 
   }
 }
+// -----------------------   end base folio classes  -------------------------
 
 
+// -----------------------  start search form folios -------------------------
 export class SzSearchParamsFolioItem extends SzFolioItem {
   _data: SzEntitySearchParams;
   name: string;
 
-  constructor(name: string, data: SzEntitySearchParams) {
-    super(); // must call super()
+  public get data (): SzEntitySearchParams {
+    return this._data;
+  }
+  public set data (value: SzEntitySearchParams) {
+    this._data = value;
+  }
 
+  constructor(data: SzEntitySearchParams) {
+    super(); // must call super()
     this.data = data;
-    this.name = name;
   }
 }
 
@@ -41,10 +50,83 @@ export class SzSearchParamsFolio extends SzFolio {
   items: SzSearchParamsFolioItem[];
   name: string;
 
-  constructor(name: string, items?: SzSearchParamsFolioItem[]) {
+  constructor( items?: SzSearchParamsFolioItem[]) {
     super(); // must call super()
 
     if (items) { this.items = items; }
-    this.name = name;
+    if (name) { this.name = name; }
   }
 }
+// -----------------------    end search form folios   -------------------------
+
+// ----------------------- start search history folios -------------------------
+export class SzSearchHistoryFolioItem extends SzSearchParamsFolioItem {
+  public get name(): string {
+    let retVal;
+    if (this.data) {
+      if(this.data.NAME_FULL) { retVal = this.data.NAME_FULL; }
+    }
+    return retVal;
+  }
+  constructor( data: SzEntitySearchParams ) {
+    super(data); // must call super()
+  }
+}
+
+export class SzSearchHistoryFolio extends SzSearchParamsFolio {
+  items: SzSearchHistoryFolioItem[];
+  public name: string = 'Search History';
+  public maxItems: number = 20;
+
+  /** gets the history folio items in decending chronological order */
+  public get history(): SzSearchHistoryFolioItem[] {
+    let _items: SzSearchParamsFolioItem[] = [];
+    _items = _items.concat(this.items).reverse();
+    return _items;
+  }
+
+  constructor( items?: SzSearchHistoryFolioItem[]) {
+    super(); // must call super()
+
+    if (items) { this.items = items; }
+    if (name) { this.name = name; }
+  }
+
+  public add( item: SzSearchHistoryFolioItem ) {
+    this.items.push( item );
+    if(this.maxItems && this.items.length > this.maxItems) {
+      // remove first item (which chronologically will be farthest back in time)
+      let removedItem = this.items.shift();
+      console.warn('tempArr : ', this.items);
+    }
+  }
+
+  public toJSONObject(): {name?: string, items: any} {
+    let _items = this.items.map( (item: SzSearchHistoryFolioItem) => {
+      return item.data;
+    })
+    return {
+      name: this.name,
+      items: _items
+    }
+  }
+
+  public fromJSONObject(data: {name?: string, items: any}) {
+    if(data && data.name) { this.name = data.name;}
+    if(data && data.items && data.items.map) {
+      /*
+      let _items = data.items.map( (item) => {
+        return new SzSearchHistoryFolioItem( item );
+      });*/
+      this.items = SzSearchHistoryFolio.FolioItemsFromJSON(data.items);
+    }
+  }
+
+  static FolioItemsFromJSON( itemsJson: [] ): SzSearchHistoryFolioItem[] {
+    let _items = itemsJson.map( (item) => {
+      return new SzSearchHistoryFolioItem( item );
+    });
+    return  _items;
+  }
+}
+// ------------------------ end search history folios -------------------------

--- a/src/lib/sdk.module.ts
+++ b/src/lib/sdk.module.ts
@@ -27,6 +27,7 @@ import {
 import { SzMessageBundleService } from './services/sz-message-bundle.service';
 import { SzSearchService } from './services/sz-search.service';
 import { SzConfigurationService } from './services/sz-configuration.service';
+import { SzFoliosService } from './services/sz-folios.service';
 import { SzUIEventService } from './services/sz-ui.service';
 import { SzPdfUtilService } from './services/sz-pdf-util.service';
 import { SzPrefsService } from './services/sz-prefs.service';
@@ -62,6 +63,7 @@ import { SzConfigurationComponent } from './configuration/sz-configuration/sz-co
 import { SzPoweredByComponent } from './sz-powered-by/sz-powered-by.component';
 import { SzPreferencesComponent } from './configuration/sz-preferences/sz-preferences.component';
 import { SzPrefDictComponent } from './configuration/sz-preferences/sz-pref-dict/sz-pref-dict.component';
+import { SzFolioItem, SzSearchParamsFolio, SzSearchParamsFolioItem } from './models/folio';
 
 /**
  * Sets up a default set of service parameters for use
@@ -162,6 +164,7 @@ const SzRestConfigurationInjector = new InjectionToken<SzRestConfiguration>("SzR
     SzSearchService,
     SzConfigurationService,
     SzDataSourcesService,
+    SzFoliosService,
     SzPrefsService,
     HttpClient,
     TitleCasePipe,

--- a/src/lib/search/sz-search/sz-search.component.html
+++ b/src/lib/search/sz-search/sz-search.component.html
@@ -21,27 +21,40 @@
                       class="search-input"
                       id="entity-name"
                       type="text"
+                      list="search-history-entity-name"
                       [attr.disabled]="getDisabled('name')"
                       (keyup.enter)="onKeyEnter()"
-                      placeholder="Search for Name">
+                      placeholder="Search for Name"
+                      (input)="checkHistoryForMatchOnChange($event)">
+              <datalist *ngIf="searchHistoryName.length > 0" id="search-history-entity-name">
+                <option *ngFor="let item of searchHistoryName" [value]="item">{{item}}</option>
+              </datalist>
             </div>
             <div class="field dob" [class.disabled]="disabledFields['dob']" *ngIf="!hiddenFields['dob']">
               <label for="entity-dob">Date of Birth</label>
               <input formControlName="DATE_OF_BIRTH"
                       id="entity-dob"
                       type="text"
+                      list="search-history-entity-dob"
                       [attr.disabled]="getDisabled('dob')"
                       (keyup.enter)="onKeyEnter()"
                       placeholder="mm/dd/yyyy">
+              <datalist *ngIf="searchHistoryDob.length > 0" id="search-history-entity-dob">
+                <option *ngFor="let item of searchHistoryDob" [value]="item">{{item}}</option>
+              </datalist>
             </div>
             <div class="field identifier" [class.disabled]="disabledFields['identifier']" *ngIf="!hiddenFields['identifier']">
               <label for="entity-identifier">Identifier</label>
               <input formControlName="IDENTIFIER"
                       id="entity-identifier"
                       type="text"
+                      list="search-history-entity-identifier"
                       [attr.disabled]="getDisabled('identifier')"
                       (keyup.enter)="onKeyEnter()"
                       placeholder="Number">
+              <datalist *ngIf="searchHistoryIdentifier.length > 0" id="search-history-entity-identifier">
+                <option *ngFor="let item of searchHistoryIdentifier" [value]="item">{{item}}</option>
+              </datalist>
             </div>
             <div class="field type" [class.disabled]="disabledFields['identifierType'] || disabledFields['identifier']" *ngIf="!hiddenFields['identifier'] && !hiddenFields['identifierType']">
               <label for="entity-type">Type</label>
@@ -69,26 +82,38 @@
               <input formControlName="ADDR_FULL"
                       id="entity-address"
                       type="text"
+                      list="search-history-entity-address"
                       [attr.disabled]="getDisabled('address')"
                       (keyup.enter)="onKeyEnter()"
                       placeholder="Search for Address">
+              <datalist *ngIf="searchHistoryAddress.length > 0" id="search-history-entity-address">
+                <option *ngFor="let item of searchHistoryAddress" [value]="item">{{item}}</option>
+              </datalist>
             </div>
             <div class="field phone" [class.disabled]="disabledFields['phone']" *ngIf="!hiddenFields['phone']">
               <label for="entity-phone">Phone</label>
               <input formControlName="PHONE_NUMBER"
                       id="entity-phone"
                       type="text"
+                      list="search-history-entity-phone"
                       [attr.disabled]="getDisabled('phone')"
                       placeholder="Phone #">
+              <datalist *ngIf="searchHistoryPhone.length > 0" id="search-history-entity-phone">
+                <option *ngFor="let item of searchHistoryPhone" [value]="item">{{item}}</option>
+              </datalist>
             </div>
             <div class="field email" [class.disabled]="disabledFields['email']" *ngIf="!hiddenFields['email']">
               <label for="entity-email">Email</label>
               <input formControlName="EMAIL_ADDRESS"
                       id="entity-email"
                       type="text"
+                      list="search-history-entity-email"
                       [attr.disabled]="getDisabled('email')"
                       (keyup.enter)="onKeyEnter()"
                       placeholder="Email Address">
+              <datalist *ngIf="searchHistoryEmail.length > 0" id="search-history-entity-email">
+                <option *ngFor="let item of searchHistoryEmail" [value]="item">{{item}}</option>
+              </datalist>
             </div>
             <div class="field spacer">
 

--- a/src/lib/search/sz-search/sz-search.component.ts
+++ b/src/lib/search/sz-search/sz-search.component.ts
@@ -125,36 +125,64 @@ export class SzSearchComponent implements OnInit, OnDestroy {
     'TRUSTED_ID_NUMBER'
   ];
 
+  /** the default amount of searches to store in the search history folio. */
   private rememberLastSearches: number = 20;
 
   /** the folio items that holds last "X" searches performed */
   public search_history: SzSearchHistoryFolioItem[];
 
+  /**
+   * all the "Name" field search values from last X searches in history folio.
+   * @readonly
+   */
   public get searchHistoryName(): string[] {
     return this.getHistoryOptions('NAME_FULL');
   }
-
+  /**
+   * all the "Date of Birth" in the form from last X searches in history folio.
+   * @readonly
+   */
   public get searchHistoryDob(): string[] {
     return this.getHistoryOptions('DATE_OF_BIRTH');
   }
-
+  /**
+   * all the "Identifier" values in the form from last X searches in history folio.
+   * @readonly
+   */
   public get searchHistoryIdentifier(): string[] {
     return this.getHistoryOptions('IDENTIFIER');
   }
-
+  /**
+   * all the "Address" values in the form from last X searches in history folio.
+   * @readonly
+   */
   public get searchHistoryAddress(): string[] {
     return this.getHistoryOptions('ADDR_FULL');
   }
-
+  /**
+   * all the "Phone Number" values in the form  from last X searches in history folio.
+   * @readonly
+   */
   public get searchHistoryPhone(): string[] {
     return this.getHistoryOptions('PHONE_NUMBER');
   }
-
+  /**
+   * all the "Date of Birth" values in the form from last X searches in history folio.
+   * @readonly
+   */
   public get searchHistoryEmail(): string[] {
     return this.getHistoryOptions('EMAIL_ADDRESS');
   }
 
+  /** @internal */
   private _searchHistoryParams: SzSearchFormParams;
+  /** checks to see if a value in a field just changed due to the
+   * user selecting a value from a previous search.
+   *
+   * In the case of a "name" select the selection also populates
+   * any other parameters
+   * that were also in the form at the time of the search.
+   */
   public checkHistoryForMatchOnChange(event) {
     const _currentSearchFormParams = this.getSearchParams();
     if(_currentSearchFormParams && _currentSearchFormParams.NAME_FULL && _currentSearchFormParams.NAME_FULL !== this._searchHistoryParams) {
@@ -665,14 +693,10 @@ export class SzSearchComponent implements OnInit, OnDestroy {
           }
           // otherwise wait for initial response
         }
-        if(pJson && pJson.searchHistory) {
+        if(pJson && pJson.searchHistory && this.prefs && this.prefs.searchForm && this.prefs.searchForm.searchHistory) {
+          // getting current value from service prefs service for modality
           this.search_history = this.prefs.searchForm.searchHistory.items;
-
-          //this.search_history = pJson.searchHistory;
-          console.warn('sz-search.prefs.searchForm updated',  this.prefs.searchForm.searchHistory.items);
-        } else {
-          console.log('sz-search.prefs.searchForm not updated', pJson);
-
+          //console.log('sz-search.prefs.searchForm updated',  this.prefs.searchForm.searchHistory.items);
         }
       });
 
@@ -680,7 +704,7 @@ export class SzSearchComponent implements OnInit, OnDestroy {
         if ( folio && folio.history) {
           this.search_history = folio.history;
         }
-        console.warn('search history from folio service updated: ', folio.history, this.search_history);
+        //console.log('search history from folio service updated: ', folio.history, this.search_history);
       });
   }
 

--- a/src/lib/search/sz-search/sz-search.component.ts
+++ b/src/lib/search/sz-search/sz-search.component.ts
@@ -695,8 +695,9 @@ export class SzSearchComponent implements OnInit, OnDestroy {
         }
         if(pJson && pJson.searchHistory && this.prefs && this.prefs.searchForm && this.prefs.searchForm.searchHistory) {
           // getting current value from service prefs service for modality
-          this.search_history = this.prefs.searchForm.searchHistory.items;
-          //console.log('sz-search.prefs.searchForm updated',  this.prefs.searchForm.searchHistory.items);
+          // note: history getter is "latest-first"
+          this.search_history = this.prefs.searchForm.searchHistory.history;
+          //console.log('sz-search.prefs.searchForm from JSON',  this.prefs.searchForm.searchHistory.items);
         }
       });
 

--- a/src/lib/services/sz-folios.service.ts
+++ b/src/lib/services/sz-folios.service.ts
@@ -5,7 +5,13 @@ import { SzSearchService } from './sz-search.service';
 import { SzSearchEvent } from '../services/sz-search.service';
 import { Observable, BehaviorSubject } from 'rxjs';
 import { SzPrefsService } from './sz-prefs.service';
-
+/**
+ * A service providing access to top level Folios for things like
+ * "Saved Searches", "Search History", "Saved Projects"
+ *
+ * @export
+ * @class SzFoliosService
+ */
 @Injectable({
   providedIn: 'root'
 })
@@ -15,34 +21,32 @@ export class SzFoliosService {
 
   /** the top lvl folio that holds last "X" searches performed */
   public  search_history: SzSearchHistoryFolio = new SzSearchHistoryFolio();
+  /** the behavior subject used for broadcasting the searchHistoryUpdated event */
   private search_history$ = new BehaviorSubject( this.search_history );
+  /** the observeable that can be listend for when the search history is updated */
   public  searchHistoryUpdated: Observable<SzSearchHistoryFolio> = this.search_history$.asObservable();
 
   constructor(
     private prefs: SzPrefsService,
     public searchService: SzSearchService) {
+
     // on user search, add search params to history stack
-    this.searchService.resultsChanged.subscribe( (data) => {
-      //console.warn('SzFoliosService.searchService.resultsChanged: ', data);
-    });
-    this.searchService.parametersChanged.subscribe( (data) => {
-      //console.warn('SzFoliosService.searchService.parametersChanged', data);
-    });
     this.searchService.searchPerformed.subscribe( (evt: SzSearchEvent) => {
-      //console.warn('!!SzFoliosService!! searchPerformed', this.search_history.items);
+      // console.log('SzFoliosService searchPerformed', this.search_history.items);
       this.addToSearchHistory(evt);
     });
 
     // make sure initial value of "search_history" folios are current with that
     // from prefs storage
     this.search_history = this.prefs.searchForm.searchHistory;
-    console.warn('SzFoliosService.search_history ', this.prefs.searchForm.searchHistory);
-
+    // console.log('SzFoliosService.search_history ', this.prefs.searchForm.searchHistory);
+    /*
     this.prefs.prefsChanged.subscribe( (
       json
     ) => {
-      console.warn('SzFoliosService.prefsChanged: ', json, this.prefs.searchForm);
+      console.log('SzFoliosService.prefsChanged: ', json, this.prefs.searchForm);
     });
+    */
   }
 
   public addToSearchHistory(data: SzSearchEvent) {
@@ -51,6 +55,6 @@ export class SzFoliosService {
     this.search_history$.next( this.search_history );
     this.prefs.searchForm.searchHistory = this.search_history;
 
-    console.warn('!!SzFoliosService.addToSearchHistory !!\n\r', this.prefs.searchForm.searchHistory, this.search_history.toJSONObject());
+    // console.log('SzFoliosService.addToSearchHistory\n\r', this.prefs.searchForm.searchHistory, this.search_history.toJSONObject());
   }
 }

--- a/src/lib/services/sz-folios.service.ts
+++ b/src/lib/services/sz-folios.service.ts
@@ -1,0 +1,31 @@
+import { Injectable, Output, EventEmitter } from '@angular/core';
+
+import { SzSearchParamsFolio, SzSearchParamsFolioItem } from '../models/folio';
+import { SzSearchService } from './sz-search.service';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class SzFoliosService {
+  /** the top lvl folio that holds last "X" searches performed */
+  public search_history: SzSearchParamsFolio = new SzSearchParamsFolio("search_history");
+  /** the collection that holds the users saved searches */
+  public searches: SzSearchParamsFolio[] = [];
+
+  constructor(public searchService: SzSearchService) {
+    // on user search, add search params to history stack
+    this.searchService.resultsChanged.subscribe( (data) => {
+      console.log('SzFoliosService.searchService.resultsChanged: ', data);
+    });
+    this.searchService.parametersChanged.subscribe( (data) => {
+      console.log('SzFoliosService.searchService.parametersChanged', data);
+    });
+    this.searchService.searchPerformed.subscribe( (data) => {
+      console.log('SzFoliosService.searchService.searchPerformed', data);
+    });
+  }
+
+  public addToSearchHistory(data) {
+
+  }
+}

--- a/src/lib/services/sz-folios.service.ts
+++ b/src/lib/services/sz-folios.service.ts
@@ -1,31 +1,56 @@
 import { Injectable, Output, EventEmitter } from '@angular/core';
 
-import { SzSearchParamsFolio, SzSearchParamsFolioItem } from '../models/folio';
+import { SzSearchHistoryFolio, SzSearchParamsFolio, SzSearchHistoryFolioItem } from '../models/folio';
 import { SzSearchService } from './sz-search.service';
+import { SzSearchEvent } from '../services/sz-search.service';
+import { Observable, BehaviorSubject } from 'rxjs';
+import { SzPrefsService } from './sz-prefs.service';
 
 @Injectable({
   providedIn: 'root'
 })
 export class SzFoliosService {
-  /** the top lvl folio that holds last "X" searches performed */
-  public search_history: SzSearchParamsFolio = new SzSearchParamsFolio("search_history");
   /** the collection that holds the users saved searches */
   public searches: SzSearchParamsFolio[] = [];
 
-  constructor(public searchService: SzSearchService) {
+  /** the top lvl folio that holds last "X" searches performed */
+  public  search_history: SzSearchHistoryFolio = new SzSearchHistoryFolio();
+  private search_history$ = new BehaviorSubject( this.search_history );
+  public  searchHistoryUpdated: Observable<SzSearchHistoryFolio> = this.search_history$.asObservable();
+
+  constructor(
+    private prefs: SzPrefsService,
+    public searchService: SzSearchService) {
     // on user search, add search params to history stack
     this.searchService.resultsChanged.subscribe( (data) => {
-      console.log('SzFoliosService.searchService.resultsChanged: ', data);
+      //console.warn('SzFoliosService.searchService.resultsChanged: ', data);
     });
     this.searchService.parametersChanged.subscribe( (data) => {
-      console.log('SzFoliosService.searchService.parametersChanged', data);
+      //console.warn('SzFoliosService.searchService.parametersChanged', data);
     });
-    this.searchService.searchPerformed.subscribe( (data) => {
-      console.log('SzFoliosService.searchService.searchPerformed', data);
+    this.searchService.searchPerformed.subscribe( (evt: SzSearchEvent) => {
+      //console.warn('!!SzFoliosService!! searchPerformed', this.search_history.items);
+      this.addToSearchHistory(evt);
+    });
+
+    // make sure initial value of "search_history" folios are current with that
+    // from prefs storage
+    this.search_history = this.prefs.searchForm.searchHistory;
+    console.warn('SzFoliosService.search_history ', this.prefs.searchForm.searchHistory);
+
+    this.prefs.prefsChanged.subscribe( (
+      json
+    ) => {
+      console.warn('SzFoliosService.prefsChanged: ', json, this.prefs.searchForm);
     });
   }
 
-  public addToSearchHistory(data) {
+  public addToSearchHistory(data: SzSearchEvent) {
+    let newSearchHistoryItem = new SzSearchHistoryFolioItem(data.params);
+    this.search_history.add( newSearchHistoryItem );
+    this.search_history$.next( this.search_history );
+    this.prefs.searchForm.searchHistory = this.search_history;
 
+    console.warn('!!SzFoliosService.addToSearchHistory !!\n\r', this.prefs.searchForm.searchHistory, this.search_history.toJSONObject());
   }
 }

--- a/src/lib/services/sz-folios.service.ts
+++ b/src/lib/services/sz-folios.service.ts
@@ -40,13 +40,16 @@ export class SzFoliosService {
     // from prefs storage
     this.search_history = this.prefs.searchForm.searchHistory;
     // console.log('SzFoliosService.search_history ', this.prefs.searchForm.searchHistory);
-    /*
-    this.prefs.prefsChanged.subscribe( (
-      json
-    ) => {
-      console.log('SzFoliosService.prefsChanged: ', json, this.prefs.searchForm);
-    });
-    */
+    if( this.prefs ) {
+      this.prefs.prefsChanged.subscribe( (
+        json
+      ) => {
+        if(json.searchForm && json.searchForm.rememberLastSearches) {
+          this.search_history.maxItems = json.searchForm.rememberLastSearches
+        }
+        console.log('SzSearchHistoryFolio.prefsChanged: ', json, this.prefs.searchForm.rememberLastSearches);
+      });
+    }
   }
 
   public addToSearchHistory(data: SzSearchEvent) {

--- a/src/lib/services/sz-folios.service.ts
+++ b/src/lib/services/sz-folios.service.ts
@@ -10,7 +10,6 @@ import { SzPrefsService } from './sz-prefs.service';
  * "Saved Searches", "Search History", "Saved Projects"
  *
  * @export
- * @class SzFoliosService
  */
 @Injectable({
   providedIn: 'root'
@@ -47,7 +46,7 @@ export class SzFoliosService {
         if(json.searchForm && json.searchForm.rememberLastSearches) {
           this.search_history.maxItems = json.searchForm.rememberLastSearches
         }
-        console.log('SzSearchHistoryFolio.prefsChanged: ', json, this.prefs.searchForm.rememberLastSearches);
+        //console.log('SzSearchHistoryFolio.prefsChanged: ', json, this.prefs.searchForm.rememberLastSearches);
       });
     }
   }

--- a/src/lib/services/sz-prefs.service.ts
+++ b/src/lib/services/sz-prefs.service.ts
@@ -1,6 +1,8 @@
 import { Injectable, OnDestroy } from '@angular/core';
 import { Subject, BehaviorSubject, merge, timer } from 'rxjs';
 import { takeUntil, debounce, filter } from 'rxjs/operators';
+import { SzSearchHistoryFolio, SzSearchParamsFolio } from '../models/folio';
+import { SzSearchHistoryFolioItem } from '@senzing/sdk-components-ng/public_api';
 //import { Configuration as SzRestConfiguration, ConfigurationParameters as SzRestConfigurationParameters } from '@senzing/rest-api-client-ng';
 
 /*
@@ -48,7 +50,7 @@ export class SzSdkPrefsBase {
       this.jsonKeys.forEach((k: string) => {
         if( this[k] !== undefined){
           try{
-            retObj[k] = this[k];
+            retObj[k] = ( this[k] && this[k].toJSONObject ) ? this[k].toJSONObject() : this[k];
           } catch (err) {
             // console.warn('attempted to get prefVal, but pref unset. ', err)
           };
@@ -65,7 +67,7 @@ export class SzSdkPrefsBase {
       this.jsonKeys.forEach((k: string) => {
         if( value[k] !== undefined ){
           try{
-            this[k] = value[k];
+            this[k] = (value[k] && value[k].fromJSONObject ) ? value[k].fromJSONObject() : value[k];
             _isChanged = true;
           } catch (err) {
             // console.warn('attempted to get prefVal, but pref unset. ', err)
@@ -101,7 +103,8 @@ export class SzSearchFormPrefs extends SzSdkPrefsBase {
   // --------------- private vars
   /** @internal */
   private _rememberLastSearches: number = 10;
-  private _savedSearches: [];
+  private _savedSearches: SzSearchParamsFolio[];
+  private _searchHistory: SzSearchHistoryFolio;
   private _allowedTypeAttributes: string[] = [
     'NIN_NUMBER',
     'ACCOUNT_NUMBER',
@@ -118,7 +121,10 @@ export class SzSearchFormPrefs extends SzSdkPrefsBase {
    * to output in json, or to take as json input
    */
   jsonKeys = [
-    'allowedTypeAttributes'
+    'rememberLastSearches',
+    'allowedTypeAttributes',
+    'savedSearches',
+    'searchHistory'
   ]
 
   // ------------------- getters and setters
@@ -132,15 +138,23 @@ export class SzSearchFormPrefs extends SzSdkPrefsBase {
     if(!this.bulkSet) this.prefsChanged.next( this.toJSONObject() );
   }
   /** get list of last searches performed. */
-  public get savedSearches(): [] {
+  public get savedSearches(): SzSearchParamsFolio[] {
     return this._savedSearches;
   }
   /** update list of last searches performed. */
-  public set savedSearches(value: []) {
+  public set savedSearches(value: SzSearchParamsFolio[]) {
     this._savedSearches = value;
     if(!this.bulkSet) this.prefsChanged.next( this.toJSONObject() );
   }
-
+  /** get list of last searches performed. */
+  public get searchHistory(): SzSearchHistoryFolio {
+    return this._searchHistory;
+  }
+  /** update list of last searches performed. */
+  public set searchHistory(value: SzSearchHistoryFolio) {
+    this._searchHistory = value;
+    if(!this.bulkSet) this.prefsChanged.next( this.toJSONObject() );
+  }
   /** the allowed identifier types to show in the identifier pulldown */
   public get allowedTypeAttributes(): string[] {
     return this._allowedTypeAttributes;
@@ -159,6 +173,60 @@ export class SzSearchFormPrefs extends SzSdkPrefsBase {
      * instead of the empty superclass
      **/
     this.prefsChanged.next( this.toJSONObject() );
+  }
+
+  public fromJSONObject(value: string) {
+    this.bulkSet = true;
+    let _isChanged = false;
+    if (this.jsonKeys && this.jsonKeys.forEach) {
+      // console.warn('SzSearchFormPrefs.fromJSONObject: ', this.jsonKeys);
+      this.jsonKeys.forEach((k: string) => {
+        if( value[k] !== undefined ){
+          if( k === 'searchHistory'){
+            // special case: takes JSON in
+            // and creates SzSearchHistoryFolio with
+            // items inside it
+            const _searchHistoryFolio: SzSearchHistoryFolio = new SzSearchHistoryFolio();
+            _searchHistoryFolio.fromJSONObject(value[k]);
+
+            this._searchHistory = _searchHistoryFolio;
+            console.warn('SzSearchFormPrefs.fromJSONObject: _searchHistory = ', this._searchHistory);
+          } else {
+            try{
+              this[k] = (value[k] && value[k].fromJSONObject ) ? value[k].fromJSONObject() : value[k];
+              _isChanged = true;
+              //console.warn('SzSearchFormPrefs.fromJSONObject: "'+ k +'"', value[k].fromJSONObject());
+            } catch (err) {
+              // console.warn('attempted to get prefVal, but pref unset. ', err)
+            };
+          }
+        }
+      });
+    }
+    this.bulkSet = false;
+    if(_isChanged){
+      this.prefsChanged.next( this.toJSONObject() );
+    }
+  }
+
+  public toJSONObject() {
+    const retObj = {};
+
+    if (this.jsonKeys && this.jsonKeys.forEach) {
+      this.jsonKeys.forEach((k: string) => {
+        if( this[k] !== undefined){
+          try{
+
+            retObj[k] = ( this[k] && this[k].toJSONObject ) ? this[k].toJSONObject() : this[k];
+          } catch (err) {
+            // console.warn('attempted to get prefVal, but pref unset. ', err)
+          };
+        }
+      });
+    }
+    console.warn('SzSearchFormPrefs.toJSONObject: ', this._searchHistory, this);
+
+    return retObj;
   }
 
 }
@@ -901,8 +969,13 @@ export class SzPrefsService implements OnDestroy {
     _keys.forEach( (_k ) => {
       if( this[_k] && this[_k].fromJSONObject ){
         // object inheriting from 'SzSdkPrefsBase'
-        //console.log(`setting "${_k}" via this[_k].fromJSONObject`, value[_k]);
-        this[_k].fromJSONObject( value[_k] );
+        if( _k === 'searchForm') {
+          console.log(`setting "${_k}" via this[_k].fromJSONObject`, value[_k]);
+          this[_k].fromJSONObject( value[_k] );
+        } else {
+          this[_k].fromJSONObject( value[_k] );
+        }
+        console.log(`setting "${_k}" via this[_k].fromJSONObject`, value[_k]);
       } else {
         //   maybe top level property
         //   :-/

--- a/src/lib/services/sz-prefs.service.ts
+++ b/src/lib/services/sz-prefs.service.ts
@@ -175,6 +175,12 @@ export class SzSearchFormPrefs extends SzSdkPrefsBase {
     this.prefsChanged.next( this.toJSONObject() );
   }
 
+  /**
+   * the search form prefs contain a folio collection that automagically update
+   * when a user executes a search. Because of this additional functionality
+   * the usual fromJSONObject needs to perform some special logic to initialize
+   * the prefs from JSON like create class instances etc.
+   */
   public fromJSONObject(value: string) {
     this.bulkSet = true;
     let _isChanged = false;
@@ -190,12 +196,12 @@ export class SzSearchFormPrefs extends SzSdkPrefsBase {
             _searchHistoryFolio.fromJSONObject(value[k]);
 
             this._searchHistory = _searchHistoryFolio;
-            console.warn('SzSearchFormPrefs.fromJSONObject: _searchHistory = ', this._searchHistory);
+            // console.warn('SzSearchFormPrefs.fromJSONObject: _searchHistory = ', this._searchHistory);
           } else {
             try{
               this[k] = (value[k] && value[k].fromJSONObject ) ? value[k].fromJSONObject() : value[k];
               _isChanged = true;
-              //console.warn('SzSearchFormPrefs.fromJSONObject: "'+ k +'"', value[k].fromJSONObject());
+              // console.log('SzSearchFormPrefs.fromJSONObject: "'+ k +'"', value[k].fromJSONObject());
             } catch (err) {
               // console.warn('attempted to get prefVal, but pref unset. ', err)
             };
@@ -208,7 +214,7 @@ export class SzSearchFormPrefs extends SzSdkPrefsBase {
       this.prefsChanged.next( this.toJSONObject() );
     }
   }
-
+  /*
   public toJSONObject() {
     const retObj = {};
 
@@ -224,10 +230,9 @@ export class SzSearchFormPrefs extends SzSdkPrefsBase {
         }
       });
     }
-    console.warn('SzSearchFormPrefs.toJSONObject: ', this._searchHistory, this);
-
     return retObj;
   }
+  */
 
 }
 

--- a/src/lib/services/sz-prefs.service.ts
+++ b/src/lib/services/sz-prefs.service.ts
@@ -137,6 +137,7 @@ export class SzSearchFormPrefs extends SzSdkPrefsBase {
   /** remember last X searches in autofill. */
   public set rememberLastSearches(value: number) {
     this._rememberLastSearches = value;
+    if( this._searchHistory && this._searchHistory.maxItems !== value) { this._searchHistory.maxItems = value; }
     if(!this.bulkSet) this.prefsChanged.next( this.toJSONObject() );
   }
   /** get list of last searches performed. */
@@ -977,12 +978,12 @@ export class SzPrefsService implements OnDestroy {
       if( this[_k] && this[_k].fromJSONObject ){
         // object inheriting from 'SzSdkPrefsBase'
         if( _k === 'searchForm') {
-          console.log(`setting "${_k}" via this[_k].fromJSONObject`, value[_k]);
+          //console.log(`setting "${_k}" via this[_k].fromJSONObject`, value[_k]);
           this[_k].fromJSONObject( value[_k] );
         } else {
           this[_k].fromJSONObject( value[_k] );
         }
-        console.log(`setting "${_k}" via this[_k].fromJSONObject`, value[_k]);
+        //console.log(`setting "${_k}" via this[_k].fromJSONObject`, value[_k]);
       } else {
         //   maybe top level property
         //   :-/

--- a/src/lib/services/sz-prefs.service.ts
+++ b/src/lib/services/sz-prefs.service.ts
@@ -1,23 +1,8 @@
 import { Injectable, OnDestroy } from '@angular/core';
 import { Subject, BehaviorSubject, merge, timer } from 'rxjs';
 import { takeUntil, debounce, filter } from 'rxjs/operators';
-import { SzSearchHistoryFolio, SzSearchParamsFolio } from '../models/folio';
-import { SzSearchHistoryFolioItem } from '@senzing/sdk-components-ng/public_api';
+import { SzSearchHistoryFolio, SzSearchHistoryFolioItem, SzSearchParamsFolio } from '../models/folio';
 //import { Configuration as SzRestConfiguration, ConfigurationParameters as SzRestConfigurationParameters } from '@senzing/rest-api-client-ng';
-
-/*
-import {
-  EntityDataService,
-  ConfigService,
-  SzAttributeSearchResponse,
-  SzEntityData,
-  SzAttributeTypesResponse,
-  SzAttributeType,
-  SzAttributeSearchResult
-} from '@senzing/rest-api-client-ng';
-import { SzEntitySearchParams } from '../models/entity-search';
-import { SzGraphConfigurationService } from '@senzing/sdk-graph-components';
-*/
 
 /**
  * preferences bus base class. provides common methods for
@@ -217,26 +202,6 @@ export class SzSearchFormPrefs extends SzSdkPrefsBase {
       this.prefsChanged.next( this.toJSONObject() );
     }
   }
-  /*
-  public toJSONObject() {
-    const retObj = {};
-
-    if (this.jsonKeys && this.jsonKeys.forEach) {
-      this.jsonKeys.forEach((k: string) => {
-        if( this[k] !== undefined){
-          try{
-
-            retObj[k] = ( this[k] && this[k].toJSONObject ) ? this[k].toJSONObject() : this[k];
-          } catch (err) {
-            // console.warn('attempted to get prefVal, but pref unset. ', err)
-          };
-        }
-      });
-    }
-    return retObj;
-  }
-  */
-
 }
 
 /**

--- a/src/lib/services/sz-prefs.service.ts
+++ b/src/lib/services/sz-prefs.service.ts
@@ -103,7 +103,9 @@ export class SzSearchFormPrefs extends SzSdkPrefsBase {
   // --------------- private vars
   /** @internal */
   private _rememberLastSearches: number = 10;
+  /** @internal */
   private _savedSearches: SzSearchParamsFolio[];
+  /** @internal */
   private _searchHistory: SzSearchHistoryFolio;
   private _allowedTypeAttributes: string[] = [
     'NIN_NUMBER',

--- a/src/lib/services/sz-search.service.ts
+++ b/src/lib/services/sz-search.service.ts
@@ -14,6 +14,11 @@ import {
 } from '@senzing/rest-api-client-ng';
 import { SzEntitySearchParams } from '../models/entity-search';
 
+export interface SzSearchEvent {
+  params: SzEntitySearchParams,
+  results: SzAttributeSearchResult[]
+}
+
 @Injectable({
   providedIn: 'root'
 })
@@ -22,7 +27,7 @@ export class SzSearchService {
   private currentSearchResults: SzAttributeSearchResult[] | null = null;
   public parametersChanged = new Subject<SzEntitySearchParams>();
   public resultsChanged = new Subject<SzAttributeSearchResult[]>();
-  public searchPerformed = new Subject<{params: SzEntitySearchParams, results: SzAttributeSearchResult[]}>();
+  public searchPerformed = new Subject<SzSearchEvent>();
 
   constructor(
     private entityDataService: EntityDataService,
@@ -42,10 +47,12 @@ export class SzSearchService {
       tap((searchRes: SzAttributeSearchResponse) => console.log('SzSearchService.searchByAttributes: ', searchParms, searchRes)),
       map((searchRes: SzAttributeSearchResponse) => searchRes.data.searchResults as SzAttributeSearchResult[]),
       tap((searchRes: SzAttributeSearchResult[]) => {
+        //console.warn('SzSearchService.searchByAttributes 1: ', searchRes)
         this.searchPerformed.next({
           params: this.currentSearchParams,
           results: searchRes
         });
+        //console.warn('SzSearchService.searchByAttributes 2: ', searchRes)
       })
     );
   }

--- a/src/public_api.ts
+++ b/src/public_api.ts
@@ -11,16 +11,17 @@ export * from '@senzing/rest-api-client-ng';
 export * from './lib/common/utils';
 
 /** services */
-export * from './lib/services/sz-search.service';  // updated to use rest
-export * from './lib/services/sz-message-bundle.service';
-export * from './lib/services/sz-configuration.service';
-export * from './lib/services/sz-ui.service';
 export * from './lib/services/sz-datasources.service';
+export * from './lib/services/sz-configuration.service';
+export * from './lib/services/sz-folios.service';
+export * from './lib/services/sz-message-bundle.service';
 export * from './lib/services/sz-pdf-util.service';
 export {
   SzPrefsService,
   SzSdkPrefsModel
 } from './lib/services/sz-prefs.service';
+export * from './lib/services/sz-search.service';  // updated to use rest
+export * from './lib/services/sz-ui.service';
 
 /** components */
 export * from './lib/search/sz-search/sz-search.component';
@@ -40,6 +41,7 @@ export * from './lib/configuration/sz-preferences/sz-preferences.component';
 export * from '@senzing/sdk-graph-components';
 
 /** models */
+export * from './lib/models/folio';
 /*
 export * from './lib/models/responces/search-results/sz-search-result-entity-data';
 export * from './lib/models/entity-detail-section-data';


### PR DESCRIPTION
![2019-12-02_151124](https://user-images.githubusercontent.com/13721038/70003369-c4e51500-1517-11ea-88a0-81add56af578.png)

#109 

This is a feature for saving the last X searches in memory. The previous unique values typed in(up to the max specified in prefs) will be available via type-ahead suggestion or pulldown from the specific input box. Right now selecting a previous value just fills out the individual field, however it is possible to perform a more robust action on select. This is what I have done specifically in just the name field, when selecting a previously searched for name from the name drop-down, the name AND any other parameters present when that search was performed are auto-filled. This was only implemented in the name field because it would open up a lot of complexity checking which values should be filled over other ones etc but I think it is worth further discussion about the right way to handle this.

The arch pattern being used is abstract collection (Folio) of abstract items(FolioItem). Doing this feature this sprint allowed me to sketch out how to approach the more feature rich implementation expected for ad-hoc saving of searches/results/graphs/entities commonly referred to as the "Folio" feature.

new models/classes:
- SzFolioItem
- SzFolio
- SzSearchParamsFolioItem extends SzFolioItem
- SzSearchParamsFolio extends SzFolio
- SzSearchHistoryFolioItem extends SzSearchParamsFolioItem
- SzSearchHistoryFolio extends SzSearchParamsFolio

new services:
- SzFoliosService

new events:
- SzSearchService.parametersChanged
- SzSearchService.resultsChanged
- SzSearchService.searchPerformed


![2019-12-02_151104](https://user-images.githubusercontent.com/13721038/70003367-c44c7e80-1517-11ea-89ba-64670a56766e.png)
![2019-12-02_151036](https://user-images.githubusercontent.com/13721038/70003368-c44c7e80-1517-11ea-874c-fe22753ea101.png)
