### PR TITLE
Search History fixes

### DIFF
--- a/src/lib/models/folio.ts
+++ b/src/lib/models/folio.ts
@@ -139,9 +139,20 @@ export class SzSearchHistoryFolio extends SzSearchParamsFolio {
   /**
    * Add a new search parameter set to the stack
    */
-  public add( item: SzSearchHistoryFolioItem ) {
-    this.items.push( item );
-    this.items = this.trimItemsTo(this.maxItems);
+  public add( item: SzSearchHistoryFolioItem, overwrite:boolean = true ): Boolean {
+    let _exists = this.exists(item);
+    let retVal = false;
+    if( overwrite || !_exists){
+      this.items.push( item );
+      this.items = this.trimItemsTo(this.maxItems);
+      retVal = true;
+      // console.log('added SzSearchHistoryFolioItem: ', item);
+    } else if (_exists) {
+      // already exists
+      // console.warn('tried to add already existing item: ', item);
+      retVal = false;
+    }
+    return retVal;
   }
   /** get a json representation model of this class and its items. */
   public toJSONObject(): {name?: string, items: any} {
@@ -172,6 +183,27 @@ export class SzSearchHistoryFolio extends SzSearchParamsFolio {
       }
     }
     return _retVal;
+  }
+
+  /** whether or not the folio item passed in already exists in collection */
+  exists(item: SzSearchHistoryFolioItem): boolean {
+    let retVal = false;
+    if(item && this.items && this.items.length > 0) {
+      retVal = this.items.some( (hItem: SzSearchHistoryFolioItem) => {
+        return (JSON.stringify(hItem.data) == JSON.stringify(item.data));
+      });
+    }
+    return retVal;
+  }
+  /** returns the index position of an existing folio item */
+  indexOf(item: SzSearchHistoryFolioItem): number {
+    let retVal = -1;
+    if(item && this.items && this.items.length > 0 && this.items.findIndex) {
+      retVal = this.items.findIndex( (hItem: SzSearchHistoryFolioItem) => {
+        return (JSON.stringify(hItem.data) == JSON.stringify(item.data));
+      });
+    }
+    return retVal;
   }
 
   /**

--- a/src/lib/services/sz-folios.service.ts
+++ b/src/lib/services/sz-folios.service.ts
@@ -54,27 +54,6 @@ export class SzFoliosService {
     }
   }
 
-  public searchHistoryChanged(source: SzSearchHistoryFolio, dest: SzSearchHistoryFolio) {
-    let retVal = false;
-    if(source && !dest){
-      // no previous value
-      retVal = true;
-    } else if(source && dest){
-      // compare values
-      if(source.toJSONObject && dest.toJSONObject) {
-        // most accurate
-        // json literal
-        if(source.toJSONObject() !== dest.toJSONObject()) {
-          retVal = true;
-        }
-      }
-    } else if(!source && dest) {
-      // no new value
-      // erase existing one
-      retVal = true
-    }
-    return retVal;
-  }
   /** add search to history stack */
   public addToSearchHistory(data: SzSearchEvent) {
     let newSearchHistoryItem = new SzSearchHistoryFolioItem(data.params);

--- a/src/lib/services/sz-folios.service.ts
+++ b/src/lib/services/sz-folios.service.ts
@@ -31,14 +31,14 @@ export class SzFoliosService {
 
     // on user search, add search params to history stack
     this.searchService.searchPerformed.subscribe( (evt: SzSearchEvent) => {
-      // console.log('SzFoliosService searchPerformed', this.search_history.items);
+      //console.log('SzFoliosService searchPerformed', this.search_history.items);
       this.addToSearchHistory(evt);
     });
 
     // make sure initial value of "search_history" folios are current with that
     // from prefs storage
-    this.search_history = this.prefs.searchForm.searchHistory;
-    // console.log('SzFoliosService.search_history ', this.prefs.searchForm.searchHistory);
+    this.search_history =  this.prefs.searchForm.searchHistory ? this.prefs.searchForm.searchHistory : new SzSearchHistoryFolio();
+    console.log('SzFoliosService.search_history ', this.prefs.searchForm.searchHistory, this.search_history);
     if( this.prefs ) {
       this.prefs.prefsChanged.subscribe( (
         json


### PR DESCRIPTION
Search History was doing all sorts of **"Odd"** things. This catches **most**(_if not all_) of the edge-cases in logic. #123 

* prevents adding duplicate history entries
* SzFoliosService re-wired to use prefs reference indirectly by referencing local getter. This way there is no need to "sync" the shallow reference items.
* SzFoliosService will attempt to create prefs searchForm history folio if not set properly or previously initialized.