### PR TITLE
pref for disabling search history #125

### DIFF
--- a/src/lib/configuration/sz-preferences/sz-preferences.component.html
+++ b/src/lib/configuration/sz-preferences/sz-preferences.component.html
@@ -1,9 +1,10 @@
 <div *ngIf="showControls" class="sz-preferences">
     <div class="prefs-ui-lists">
-        <!-- start search form prefs -->
-        <div class="prefs-ui-column prefs-ui-column-search-form">
+        <!-- start search prefs -->
+        <div class="prefs-ui-column prefs-ui-column-search">
+            <!-- start search form prefs -->
             <h4 class="title">Search</h4>
-            <ul class="prefs-ui-column-inner">
+            <ul class="prefs-ui-column-inner prefs-ui-column-inner-search">
                 <li *ngFor="let opt of searchFormOptions; let i = index" [attr.pref-key]="opt.name">
                     <input *ngIf="opt.inputType == 'checkbox'" [attr.id]="'c1-opts-search-form-'+ i" type="checkbox"
                     [checked]="boolPrefChecked('searchForm', opt.name)"
@@ -16,10 +17,8 @@
                     <label [attr.for]="'c1-opts-search-form-'+ i">{{ toSentenceCase(opt.name) | titlecase }}</label>
                 </li>
             </ul>
-        </div>
-        <!-- end search form prefs -->
-        <!-- start search results prefs -->
-        <div class="prefs-ui-column prefs-ui-column-search-results">
+            <!-- end search form prefs -->
+            <!-- start search results prefs -->
             <h4 class="title">Search Results</h4>
             <ul class="prefs-ui-column-inner">
                 <li *ngFor="let opt of searchResultsOptions; let i = index" [attr.pref-key]="opt.name">
@@ -34,8 +33,9 @@
                     <label [attr.for]="'c2-opts-search-results-'+ i">{{ toSentenceCase(opt.name) | titlecase }}<!-- <span class="pref-key">({{opt.name}})</span> --></label>
                 </li>
             </ul>
+            <!-- end search results prefs -->
         </div>
-        <!-- end search results prefs -->
+        <!-- end search prefs -->
         <!-- start entity detail prefs -->
         <div class="prefs-ui-column prefs-ui-column-entity-detail">
             <h4 class="title">Entity Detail</h4>

--- a/src/lib/configuration/sz-preferences/sz-preferences.component.scss
+++ b/src/lib/configuration/sz-preferences/sz-preferences.component.scss
@@ -54,6 +54,9 @@
 
     .prefs-ui-column-inner {
       display: inline-block;
+      &.prefs-ui-column-inner-search {
+        margin-bottom: 20px;
+      }
     }
   }
 }

--- a/src/lib/configuration/sz-preferences/sz-preferences.component.spec.ts
+++ b/src/lib/configuration/sz-preferences/sz-preferences.component.spec.ts
@@ -42,10 +42,10 @@ describe('SzPreferencesComponent', () => {
   });
 
   describe('should have column: ', () => {
-    it('search results', () => {
+    it('search', () => {
       fixture.componentInstance.showControls = true;
       fixture.detectChanges();
-      let dbgEle = fixture.debugElement.query( By.css('.prefs-ui-column-search-results'));
+      let dbgEle = fixture.debugElement.query( By.css('.prefs-ui-column-search'));
       expect(dbgEle).toBeTruthy();
     });
     it('entity detail', () => {

--- a/src/lib/search/sz-search/sz-search.component.html
+++ b/src/lib/search/sz-search/sz-search.component.html
@@ -26,7 +26,7 @@
                       (keyup.enter)="onKeyEnter()"
                       placeholder="Search for Name"
                       (input)="checkHistoryForMatchOnChange($event)">
-              <datalist *ngIf="searchHistoryName.length > 0" id="search-history-entity-name">
+              <datalist *ngIf="searchHistoryName.length > 0 && !searchHistoryDisabled" id="search-history-entity-name">
                 <option *ngFor="let item of searchHistoryName" [value]="item">{{item}}</option>
               </datalist>
             </div>
@@ -39,7 +39,7 @@
                       [attr.disabled]="getDisabled('dob')"
                       (keyup.enter)="onKeyEnter()"
                       placeholder="mm/dd/yyyy">
-              <datalist *ngIf="searchHistoryDob.length > 0" id="search-history-entity-dob">
+              <datalist *ngIf="searchHistoryDob.length > 0 && !searchHistoryDisabled" id="search-history-entity-dob">
                 <option *ngFor="let item of searchHistoryDob" [value]="item">{{item}}</option>
               </datalist>
             </div>
@@ -52,7 +52,7 @@
                       [attr.disabled]="getDisabled('identifier')"
                       (keyup.enter)="onKeyEnter()"
                       placeholder="Number">
-              <datalist *ngIf="searchHistoryIdentifier.length > 0" id="search-history-entity-identifier">
+              <datalist *ngIf="searchHistoryIdentifier.length > 0 && !searchHistoryDisabled" id="search-history-entity-identifier">
                 <option *ngFor="let item of searchHistoryIdentifier" [value]="item">{{item}}</option>
               </datalist>
             </div>
@@ -86,7 +86,7 @@
                       [attr.disabled]="getDisabled('address')"
                       (keyup.enter)="onKeyEnter()"
                       placeholder="Search for Address">
-              <datalist *ngIf="searchHistoryAddress.length > 0" id="search-history-entity-address">
+              <datalist *ngIf="searchHistoryAddress.length > 0 && !searchHistoryDisabled" id="search-history-entity-address">
                 <option *ngFor="let item of searchHistoryAddress" [value]="item">{{item}}</option>
               </datalist>
             </div>
@@ -98,7 +98,7 @@
                       list="search-history-entity-phone"
                       [attr.disabled]="getDisabled('phone')"
                       placeholder="Phone #">
-              <datalist *ngIf="searchHistoryPhone.length > 0" id="search-history-entity-phone">
+              <datalist *ngIf="searchHistoryPhone.length > 0 && !searchHistoryDisabled" id="search-history-entity-phone">
                 <option *ngFor="let item of searchHistoryPhone" [value]="item">{{item}}</option>
               </datalist>
             </div>
@@ -111,7 +111,7 @@
                       [attr.disabled]="getDisabled('email')"
                       (keyup.enter)="onKeyEnter()"
                       placeholder="Email Address">
-              <datalist *ngIf="searchHistoryEmail.length > 0" id="search-history-entity-email">
+              <datalist *ngIf="searchHistoryEmail.length > 0 && !searchHistoryDisabled" id="search-history-entity-email">
                 <option *ngFor="let item of searchHistoryEmail" [value]="item">{{item}}</option>
               </datalist>
             </div>

--- a/src/lib/search/sz-search/sz-search.component.ts
+++ b/src/lib/search/sz-search/sz-search.component.ts
@@ -128,6 +128,14 @@ export class SzSearchComponent implements OnInit, OnDestroy {
   /** the default amount of searches to store in the search history folio. */
   private rememberLastSearches: number = 20;
 
+  /** whether or not to display search history drop downs. set from searchform prefs */
+  public get searchHistoryDisabled(): boolean {
+    if(this.prefs && this.prefs.searchForm) {
+      return this.prefs.searchForm.disableSearchHistory;
+    }
+    return false;
+  }
+
   /** the folio items that holds last "X" searches performed */
   public search_history: SzSearchHistoryFolioItem[];
 

--- a/src/lib/services/sz-prefs.service.ts
+++ b/src/lib/services/sz-prefs.service.ts
@@ -89,6 +89,8 @@ export class SzSearchFormPrefs extends SzSdkPrefsBase {
   /** @internal */
   private _rememberLastSearches: number = 10;
   /** @internal */
+  private _disableSearchHistory: boolean = false;
+  /** @internal */
   private _savedSearches: SzSearchParamsFolio[];
   /** @internal */
   private _searchHistory: SzSearchHistoryFolio;
@@ -109,6 +111,7 @@ export class SzSearchFormPrefs extends SzSdkPrefsBase {
    */
   jsonKeys = [
     'rememberLastSearches',
+    'disableSearchHistory',
     'allowedTypeAttributes',
     'savedSearches',
     'searchHistory'
@@ -123,6 +126,15 @@ export class SzSearchFormPrefs extends SzSdkPrefsBase {
   public set rememberLastSearches(value: number) {
     this._rememberLastSearches = value;
     if( this._searchHistory && this._searchHistory.maxItems !== value) { this._searchHistory.maxItems = value; }
+    if(!this.bulkSet) this.prefsChanged.next( this.toJSONObject() );
+  }
+  /** whether or not to disable search form history drop downs. */
+  public get disableSearchHistory(): boolean {
+    return this._disableSearchHistory;
+  }
+  /** whether or not to disable search form history drop downs. */
+  public set disableSearchHistory(value: boolean) {
+    this._disableSearchHistory = value;
     if(!this.bulkSet) this.prefsChanged.next( this.toJSONObject() );
   }
   /** get list of last searches performed. */


### PR DESCRIPTION
- added pref to enable/disable search history feature. 
- combined "form" and "results" prefs in to single column to save space.

![2019-12-09_113438](https://user-images.githubusercontent.com/13721038/70466464-07f33b00-1a78-11ea-850d-46f494bfb800.png)
 
Issue number: #125 