### PR TITLE
#162 fix for FF color picker being weird

### DIFF
--- a/src/lib/entity/detail/sz-entity-detail-graph/sz-entity-detail-graph-filter.component.html
+++ b/src/lib/entity/detail/sz-entity-detail-graph/sz-entity-detail-graph-filter.component.html
@@ -78,7 +78,7 @@
         <ng-container *ngIf="shouldDataSourceBeDisplayed(_datasources[i])">
           <li formArrayName="datasources">
             <label>
-              <input type="color" [formControlName]="i" (change)="onDsColorChange()">{{_datasources[i]}}
+              <input type="color" [formControlName]="i" [style.background-color]="getDataSourceColor(_datasources[i])" (change)="onDsColorChange($event.target, $event)">{{_datasources[i]}}
             </label>
           </li>
         </ng-container>
@@ -96,6 +96,7 @@
           Active/Focused Enitity
           <span class="tooltip tooptip-left">The color of the current entity or entities</span>
         </span>
+        <small class="note-sub">(*note overrides datasource member color if selected)</small>
       </label>
     </li>
   </ul>

--- a/src/lib/entity/detail/sz-entity-detail-graph/sz-entity-detail-graph-filter.component.scss
+++ b/src/lib/entity/detail/sz-entity-detail-graph/sz-entity-detail-graph-filter.component.scss
@@ -66,12 +66,35 @@
       padding-bottom: 0;
     }
     input[type=color] {
+      border-color: #676767;
+      border-image: none;
+      border-radius: 3px;
+      border-width: 2px;
+      cursor: pointer;
       display: inline-block;
-      width: 15px;
-      height: 18px;
+      gap: revert;
+      height: 14px;
       margin: 0 7px 0 0;
+      padding: 0 7px ;
+      text-decoration: none;
+      width: 0px;
     }
   }
+}
+
+@-moz-document url-prefix() { 
+  ul.colors-list, ul.other-colors-list {
+    input[type=color] {
+      border-width: 1px !important;
+      padding: 0 !important;
+      width: 14px !important;
+    }
+  }
+}
+
+.note-sub {
+  display: block;
+  font-style: italic;
 }
 
 .has-tooltip {

--- a/src/lib/entity/detail/sz-entity-detail-graph/sz-entity-detail-graph-filter.component.ts
+++ b/src/lib/entity/detail/sz-entity-detail-graph/sz-entity-detail-graph-filter.component.ts
@@ -140,8 +140,29 @@ export class SzEntityDetailGraphFilterComponent implements OnInit, OnDestroy {
     this.prefs.graph.dataSourcesFiltered = filteredDataSourceNames;
     //console.log('onDsFilterChange: ', filteredDataSourceNames, this.prefs.graph.dataSourcesFiltered);
   }
+  /**
+   * method for getting the selected pref color for a datasource 
+   * by the datasource name. used for applying background color to 
+   * input[type=color] to make them look fancier
+   */
+  getDataSourceColor(dsValue) {
+    const coloredDataSourceNames = this.colorsByDataSourcesForm.value.datasources
+      .map((v, i) => {
+        const hasColor = v ? true : false;
+        return v ? {'key': this._datasources[i], 'value': v} : null;
+      })
+      .filter(v => v !== null);
+    
+    let dsFormValMatch = coloredDataSourceNames.find( (_keyValPair) => {
+      return _keyValPair.key === dsValue ? true : false;
+    });
+    if(dsFormValMatch) {
+      return dsFormValMatch.value;
+    }
+    return 'transparent';
+  }
   /** handler for when a color value for a source in the "colorsByDataSourcesForm" has changed */
-  onDsColorChange() {
+  onDsColorChange(src?: any, evt?) {
     const coloredDataSourceNames = this.colorsByDataSourcesForm.value.datasources
       .map((v, i) => {
         const hasColor = v ? true : false;
@@ -149,11 +170,14 @@ export class SzEntityDetailGraphFilterComponent implements OnInit, OnDestroy {
       })
       .filter(v => v !== null);
 
-      coloredDataSourceNames.forEach( (pair) => {
-        this.dataSourceColors[pair.key] = pair.value;
-      });
+    coloredDataSourceNames.forEach( (pair) => {
+      this.dataSourceColors[pair.key] = pair.value;
+    });
+    // update color swatch bg color(for prettier boxes)
+    if(src && src.style && src.style.setProperty){
+      src.style.setProperty('background-color', src.value);
+    }
     // update colors pref
-    //console.log('onDsColorChange: ', this.dataSourceColors, coloredDataSourceNames);
     if( this.prefs && this.prefs.graph) {
       // there is some sort of mem reference clone issue
       // forcing update seems to fix it
@@ -180,7 +204,7 @@ export class SzEntityDetailGraphFilterComponent implements OnInit, OnDestroy {
     } else if (event.srcElement) {
       _checked = event.srcElement.checked;
     }
-    console.log('@senzing/sdk-components-ng/SzEntityDetailGraphFilterComponent.onCheckboxPrefToggle: ', _checked, optName, event);
+    //console.log('@senzing/sdk-components-ng/SzEntityDetailGraphFilterComponent.onCheckboxPrefToggle: ', _checked, optName, event);
     this.optionChanged.emit({'name': optName, value: _checked});
   }
   /** proxy handler for when prefs have changed externally */

--- a/src/lib/entity/detail/sz-entity-detail-graph/sz-standalone-graph.component.ts
+++ b/src/lib/entity/detail/sz-entity-detail-graph/sz-standalone-graph.component.ts
@@ -437,7 +437,9 @@ export class SzStandaloneGraphComponent implements OnInit, OnDestroy {
     this.dataSourceColors = prefs.dataSourceColors;
     this.dataSourcesFiltered = prefs.dataSourcesFiltered;
     this.neverFilterQueriedEntityIds = prefs.neverFilterQueriedEntityIds;
-    this.queriedEntitiesColor = prefs.queriedEntitiesColor;
+    if(prefs.queriedEntitiesColor && prefs.queriedEntitiesColor !== undefined && prefs.queriedEntitiesColor !== null) {
+      this.queriedEntitiesColor = prefs.queriedEntitiesColor;
+    }
     if(this.graphNetworkComponent && queryParamChanged) {
       // update graph with new properties
       this.graphNetworkComponent.maxDegrees = this.maxDegrees;
@@ -462,7 +464,7 @@ export class SzStandaloneGraphComponent implements OnInit, OnDestroy {
       _ret = _keys.map( (_key) => {
         const _color = this.dataSourceColors[_key];
         return {
-          selectorFn: this.isEntityNodeInDataSource.bind(this, _key),
+          selectorFn: this.isEntityNodeInDataSource.bind(this, true, _key),
           modifierFn: this.setEntityNodeFillColor.bind(this, _color),
           selectorArgs: _key,
           modifierArgs: _color
@@ -478,7 +480,7 @@ export class SzStandaloneGraphComponent implements OnInit, OnDestroy {
       if( this.graph && this.graph.isD3) {
         _ret = this.dataSourcesFiltered.map( (_name) => {
           return {
-            selectorFn: this.isEntityNodeInDataSource.bind(this, _name),
+            selectorFn: this.isEntityNodeInDataSource.bind(this, false, _name),
             selectorArgs: _name
           };
         });
@@ -498,7 +500,7 @@ export class SzStandaloneGraphComponent implements OnInit, OnDestroy {
   /** get an array of NodeFilterPair to use for highlighting certain graph nodes specific colors */
   public get entityNodeColors(): NodeFilterPair[] {
     const _ret = this.entityNodecolorsByDataSource;
-    if( this.queriedEntitiesColor && this.queriedEntitiesColor !== undefined){
+    if( this.queriedEntitiesColor && this.queriedEntitiesColor !== undefined && this.queriedEntitiesColor !== null){
       // add special color for active/primary nodes
       _ret.push( {
         selectorFn: this.isEntityNodeInQuery.bind(this),
@@ -510,10 +512,12 @@ export class SzStandaloneGraphComponent implements OnInit, OnDestroy {
     return _ret;
   }
   /** used by "entityNodecolorsByDataSource" getter to query nodes as belonging to a datasource */
-  private isEntityNodeInDataSource(dataSource, nodeData) {
-    // console.log('fromOwners: ', nodeData);
+  private isEntityNodeInDataSource(isColorQuery, dataSource, nodeData) {
     const _retVal = false;
-    if(this.neverFilterQueriedEntityIds && this.graphIds.indexOf( nodeData.entityId ) >= 0){
+    const _hasActiveEntColorSet = ( this.queriedEntitiesColor && this.queriedEntitiesColor !== undefined && this.queriedEntitiesColor !== null) ? true : false;
+
+    if(this.neverFilterQueriedEntityIds && this.graphIds.indexOf( nodeData.entityId ) >= 0 && 
+    ((isColorQuery && _hasActiveEntColorSet) || !isColorQuery)){
       return false;
     } else {
       if(nodeData && nodeData.dataSources && nodeData.dataSources.indexOf){
@@ -525,6 +529,8 @@ export class SzStandaloneGraphComponent implements OnInit, OnDestroy {
       }
     }
   }
+  /*
+  @deprecated
   private isEntityNodeInDataSources(dataSources, nodeData) {
     // console.log('fromOwners: ', nodeData);
     console.log('isEntityNodeInDataSources: ', dataSources, nodeData);
@@ -544,7 +550,7 @@ export class SzStandaloneGraphComponent implements OnInit, OnDestroy {
         return false;
       }
     }
-  }
+  }*/
   private isEntityNodeNotInDataSources(dataSources, nodeData) {
     //console.log('isEntityNodeNotInDataSources: ', dataSources, nodeData);
     if(this.neverFilterQueriedEntityIds && this.graphIds.indexOf( nodeData.entityId ) >= 0){


### PR DESCRIPTION
# Pull request questions

## Which issue does this address

resolves #162

## Why was change needed

color picker was acting weird in Firefox.. also there was a scenario where datasource colors were never being applied to primary nodes(ie, nodes in the initial search result). Also, when "active/focused" entity color is selected it will override any per-datasource color(s) that may normally apply to those nodes. I added a * **note** in there about that for now, the real fix is probably to do a custom control list(like drag to reorder, unselect etc)

## What does change improve
![2020-10-01_194140](https://user-images.githubusercontent.com/13721038/94883001-65e57a80-041e-11eb-88fe-6c98e6952495.png)

