### PR TITLE
Issue111.awinters.1

### DIFF
--- a/src/lib/common/utils.ts
+++ b/src/lib/common/utils.ts
@@ -1,3 +1,4 @@
+import { SzDataSourceComposite } from '../models/data-sources';
 
 /**
  * A reusable function to remove any null or undefined values, and their
@@ -24,3 +25,31 @@ export function parseBool(value: any): boolean {
   } else if (value > 0) { return true; }
   return false;
 };
+
+/**
+ * Function used to return an array of "SzDataSourceComposite" in the order 
+ * specified by each members "index" property
+ */
+export function sortDataSourcesByIndex(value: SzDataSourceComposite[]): SzDataSourceComposite[] {
+  let retVal  = value;
+  if(retVal && retVal.sort) {
+    // first sort by any existing indexes
+    retVal = retVal.sort((a, b) => {    
+        if (a.index > b.index) {
+            return 1;
+        } else if (a.index < b.index) {    
+            return -1;
+        } else {
+          // sort by name
+        }
+        return 0;
+    });
+    // now update index values to same as array
+    retVal  = retVal.map((_dsVal: SzDataSourceComposite, _index: number) => {
+      let _reIndexed  = _dsVal;
+      _reIndexed.index = _index;
+      return _reIndexed;
+    });
+  }
+  return retVal;
+}

--- a/src/lib/entity/detail/sz-entity-detail-graph/sz-entity-detail-graph-filter.component.html
+++ b/src/lib/entity/detail/sz-entity-detail-graph/sz-entity-detail-graph-filter.component.html
@@ -60,10 +60,10 @@
   <form [formGroup]="filterByDataSourcesForm">
   <ul class="filters-list">
     <ng-container *ngFor="let ds of filterByDataSourcesData.controls; let i = index">
-        <ng-container *ngIf="shouldDataSourceBeDisplayed(dataSourcesOrdered[i].name)">
+        <ng-container *ngIf="shouldDataSourceBeDisplayed(dataSources[i].name)">
             <li formArrayName="datasources">
               <label>
-                <input type="checkbox" [formControlName]="i" (change)="onDsFilterChange(dataSourcesOrdered[i].name, $event)">{{dataSourcesOrdered[i].name}}
+                <input type="checkbox" [formControlName]="i" (change)="onDsFilterChange(dataSources[i].name, $event)">{{dataSources[i].name}}
               </label>
             </li>
         </ng-container>
@@ -72,7 +72,7 @@
   </form>
   <!--
   <ul class="filters-list">
-    <ng-container *ngFor="let ds of dataSourcesOrdered; let i = index">
+    <ng-container *ngFor="let ds of dataSources; let i = index">
         <ng-container *ngIf="shouldDataSourceBeDisplayed(ds.name)">
             <li>
               <label>
@@ -86,7 +86,7 @@
   <hr>
   <h3>{{ sectionTitles[2] }}</h3>
   <ul cdkDropList class="colors-list" (cdkDropListDropped)="onColorOrderDrop($event)">
-    <ng-container *ngFor="let ds of dataSourceColorsOrdered; let i = index">
+    <ng-container *ngFor="let ds of dataSourceColors; let i = index">
       <li class="color-box" *ngIf="shouldDataSourceBeDisplayed(ds.name)" cdkDrag [cdkDragData]="ds.name">
         <div class="color-box-placeholder" *cdkDragPlaceholder></div>
         <label>

--- a/src/lib/entity/detail/sz-entity-detail-graph/sz-entity-detail-graph-filter.component.html
+++ b/src/lib/entity/detail/sz-entity-detail-graph/sz-entity-detail-graph-filter.component.html
@@ -96,16 +96,17 @@
   <form [formGroup]="colorsByDataSourcesForm">
   <ul cdkDropList class="example-list" (cdkDropListDropped)="onColorOrderDrop($event)">
     <ng-container *ngFor="let ds of dataSourceColorsOrdered; let i = index">
-      <li class="example-box" formArrayName="datasources" *ngIf="shouldDataSourceBeDisplayed(dataSourceColorsOrdered[i].datasource)" cdkDrag>
+      <li class="example-box" formArrayName="datasources" *ngIf="shouldDataSourceBeDisplayed(dataSourceColorsOrdered[i].name)" cdkDrag [cdkDragData]="dataSourceColorsOrdered[i].name">
         <div class="example-custom-placeholder" *cdkDragPlaceholder></div>
         <label>
-          <input type="color" [formControlName]="i" [style.background-color]="dataSourceColorsOrdered[i].color" (change)="onDsColorChange($event.target, $event)">
-          {{dataSourceColorsOrdered[i].datasource}}
+          <input type="color" [formControlName]="i" [style.background-color]="getDataSourceColor(dataSourceColorsOrdered[i].name)" (change)="onDsColorChange($event.target, $event)">
+          {{dataSourceColorsOrdered[i].name}}
         </label>
       </li>
     </ng-container>
   </ul>
   </form>
+  <button (click)="getOrderedColors()">Get Ordered</button>
 
   <hr>
   <h3>{{ sectionTitles[3] }}</h3>

--- a/src/lib/entity/detail/sz-entity-detail-graph/sz-entity-detail-graph-filter.component.html
+++ b/src/lib/entity/detail/sz-entity-detail-graph/sz-entity-detail-graph-filter.component.html
@@ -57,7 +57,7 @@
 
   <hr>
   <h3>{{ sectionTitles[1] }}</h3>
-  <form [formGroup]="filterByDataSourcesForm">
+  <!--<form [formGroup]="filterByDataSourcesForm">
   <ul class="filters-list">
     <ng-container *ngFor="let ds of filterByDataSourcesData.controls; let i = index">
         <ng-container *ngIf="shouldDataSourceBeDisplayed(_datasources[i])">
@@ -69,44 +69,34 @@
         </ng-container>
     </ng-container>
   </ul>
-  </form>
-  <hr>
-  <!--<h3>{{ sectionTitles[2] }}</h3>
-  <form [formGroup]="colorsByDataSourcesForm">
-  <ul class="colors-list">
-    <ng-container *ngFor="let ds of colorsByDataSourcesData.controls; let i = index">
-        <ng-container *ngIf="shouldDataSourceBeDisplayed(_datasources[i])">
-          <li formArrayName="datasources">
-            <label>
-              <input type="color" [formControlName]="i" [style.background-color]="getDataSourceColor(_datasources[i])" (change)="onDsColorChange($event.target, $event)">{{_datasources[i]}}
-            </label>
-          </li>
+  </form>-->
+  <ul class="filters-list">
+    <ng-container *ngFor="let ds of dataSourcesOrdered; let i = index">
+        <ng-container *ngIf="shouldDataSourceBeDisplayed(ds.name)">
+            <li>
+              <label>
+                <input type="checkbox" [(ngModel)]="!ds.hidden" (change)="onDsFilterChange(ds.name, $event)">{{ds.name}}
+              </label>
+            </li>
         </ng-container>
     </ng-container>
   </ul>
-  </form>-->
   <hr>
   <h3>{{ sectionTitles[2] }}</h3>
-  <!--<div cdkDropList class="example-list" (cdkDropListDropped)="drop($event)">
-    <div class="example-box" *ngFor="let movie of movies" cdkDrag>
-      <div class="example-custom-placeholder" *cdkDragPlaceholder></div>
-      {{movie}}
-    </div>
-  </div>-->
-  <form [formGroup]="colorsByDataSourcesForm">
-  <ul cdkDropList class="example-list" (cdkDropListDropped)="onColorOrderDrop($event)">
+  <ul cdkDropList class="colors-list" (cdkDropListDropped)="onColorOrderDrop($event)">
     <ng-container *ngFor="let ds of dataSourceColorsOrdered; let i = index">
-      <li class="example-box" formArrayName="datasources" *ngIf="shouldDataSourceBeDisplayed(dataSourceColorsOrdered[i].name)" cdkDrag [cdkDragData]="dataSourceColorsOrdered[i].name">
-        <div class="example-custom-placeholder" *cdkDragPlaceholder></div>
+      <li class="color-box" *ngIf="shouldDataSourceBeDisplayed(ds.name)" cdkDrag [cdkDragData]="ds.name">
+        <div class="color-box-placeholder" *cdkDragPlaceholder></div>
         <label>
-          <input type="color" [formControlName]="i" [style.background-color]="getDataSourceColor(dataSourceColorsOrdered[i].name)" (change)="onDsColorChange($event.target, $event)">
-          {{dataSourceColorsOrdered[i].name}}
+          <input type="color" [(ngModel)]="ds.color" [style.background-color]="getDataSourceColor(ds.name)" (change)="onDsColorChange(ds.name, $event.target, $event)">
+          {{ds.name}}
         </label>
+        <div class="color-box-handle" cdkDragHandle>
+          <mat-icon aria-hidden="false" aria-label="drag option">drag_handle</mat-icon>
+        </div>
       </li>
     </ng-container>
   </ul>
-  </form>
-  <button (click)="getOrderedColors()">Get Ordered</button>
 
   <hr>
   <h3>{{ sectionTitles[3] }}</h3>

--- a/src/lib/entity/detail/sz-entity-detail-graph/sz-entity-detail-graph-filter.component.html
+++ b/src/lib/entity/detail/sz-entity-detail-graph/sz-entity-detail-graph-filter.component.html
@@ -57,19 +57,20 @@
 
   <hr>
   <h3>{{ sectionTitles[1] }}</h3>
-  <!--<form [formGroup]="filterByDataSourcesForm">
+  <form [formGroup]="filterByDataSourcesForm">
   <ul class="filters-list">
     <ng-container *ngFor="let ds of filterByDataSourcesData.controls; let i = index">
-        <ng-container *ngIf="shouldDataSourceBeDisplayed(_datasources[i])">
+        <ng-container *ngIf="shouldDataSourceBeDisplayed(dataSourcesOrdered[i].name)">
             <li formArrayName="datasources">
               <label>
-                <input type="checkbox" [formControlName]="i" (change)="onDsFilterChange()">{{_datasources[i]}}
+                <input type="checkbox" [formControlName]="i" (change)="onDsFilterChange(dataSourcesOrdered[i].name, $event)">{{dataSourcesOrdered[i].name}}
               </label>
             </li>
         </ng-container>
     </ng-container>
   </ul>
-  </form>-->
+  </form>
+  <!--
   <ul class="filters-list">
     <ng-container *ngFor="let ds of dataSourcesOrdered; let i = index">
         <ng-container *ngIf="shouldDataSourceBeDisplayed(ds.name)">
@@ -81,6 +82,7 @@
         </ng-container>
     </ng-container>
   </ul>
+  -->
   <hr>
   <h3>{{ sectionTitles[2] }}</h3>
   <ul cdkDropList class="colors-list" (cdkDropListDropped)="onColorOrderDrop($event)">

--- a/src/lib/entity/detail/sz-entity-detail-graph/sz-entity-detail-graph-filter.component.html
+++ b/src/lib/entity/detail/sz-entity-detail-graph/sz-entity-detail-graph-filter.component.html
@@ -93,19 +93,19 @@
       {{movie}}
     </div>
   </div>-->
-  
-  <div cdkDropList class="example-list" (cdkDropListDropped)="onColorOrderDrop($event)">
-    <div class="example-box" *ngFor="let ds of dataSourceColorsOrdered; let i = index" cdkDrag>
-      <ng-container *ngIf="shouldDataSourceBeDisplayed(dataSourceColorsOrdered[i].datasource)">
+  <form [formGroup]="colorsByDataSourcesForm">
+  <ul cdkDropList class="example-list" (cdkDropListDropped)="onColorOrderDrop($event)">
+    <ng-container *ngFor="let ds of dataSourceColorsOrdered; let i = index">
+      <li class="example-box" formArrayName="datasources" *ngIf="shouldDataSourceBeDisplayed(dataSourceColorsOrdered[i].datasource)" cdkDrag>
         <div class="example-custom-placeholder" *cdkDragPlaceholder></div>
         <label>
           <input type="color" [formControlName]="i" [style.background-color]="dataSourceColorsOrdered[i].color" (change)="onDsColorChange($event.target, $event)">
           {{dataSourceColorsOrdered[i].datasource}}
         </label>
-      </ng-container>
-    </div>
-  </div>
-
+      </li>
+    </ng-container>
+  </ul>
+  </form>
 
   <hr>
   <h3>{{ sectionTitles[3] }}</h3>

--- a/src/lib/entity/detail/sz-entity-detail-graph/sz-entity-detail-graph-filter.component.html
+++ b/src/lib/entity/detail/sz-entity-detail-graph/sz-entity-detail-graph-filter.component.html
@@ -71,7 +71,7 @@
   </ul>
   </form>
   <hr>
-  <h3>{{ sectionTitles[2] }}</h3>
+  <!--<h3>{{ sectionTitles[2] }}</h3>
   <form [formGroup]="colorsByDataSourcesForm">
   <ul class="colors-list">
     <ng-container *ngFor="let ds of colorsByDataSourcesData.controls; let i = index">
@@ -84,7 +84,29 @@
         </ng-container>
     </ng-container>
   </ul>
-  </form>
+  </form>-->
+  <hr>
+  <h3>{{ sectionTitles[2] }}</h3>
+  <!--<div cdkDropList class="example-list" (cdkDropListDropped)="drop($event)">
+    <div class="example-box" *ngFor="let movie of movies" cdkDrag>
+      <div class="example-custom-placeholder" *cdkDragPlaceholder></div>
+      {{movie}}
+    </div>
+  </div>-->
+  
+  <div cdkDropList class="example-list" (cdkDropListDropped)="onColorOrderDrop($event)">
+    <div class="example-box" *ngFor="let ds of dataSourceColorsOrdered; let i = index" cdkDrag>
+      <ng-container *ngIf="shouldDataSourceBeDisplayed(dataSourceColorsOrdered[i].datasource)">
+        <div class="example-custom-placeholder" *cdkDragPlaceholder></div>
+        <label>
+          <input type="color" [formControlName]="i" [style.background-color]="dataSourceColorsOrdered[i].color" (change)="onDsColorChange($event.target, $event)">
+          {{dataSourceColorsOrdered[i].datasource}}
+        </label>
+      </ng-container>
+    </div>
+  </div>
+
+
   <hr>
   <h3>{{ sectionTitles[3] }}</h3>
   <form [formGroup]="colorsMiscForm">

--- a/src/lib/entity/detail/sz-entity-detail-graph/sz-entity-detail-graph-filter.component.scss
+++ b/src/lib/entity/detail/sz-entity-detail-graph/sz-entity-detail-graph-filter.component.scss
@@ -148,3 +148,55 @@
   visibility: visible;
   opacity: 1;
 }
+
+.example-list {
+  width: 500px;
+  max-width: 100%;
+  border: solid 1px #ccc;
+  min-height: 60px;
+  display: block;
+  background: white;
+  border-radius: 4px;
+  overflow: hidden;
+}
+
+.example-box {
+  padding: 20px 10px;
+  border-bottom: solid 1px #ccc;
+  color: rgba(0, 0, 0, 0.87);
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: space-between;
+  box-sizing: border-box;
+  cursor: move;
+  background: white;
+  font-size: 14px;
+}
+
+.cdk-drag-preview {
+  box-sizing: border-box;
+  border-radius: 4px;
+  box-shadow: 0 5px 5px -3px rgba(0, 0, 0, 0.2),
+              0 8px 10px 1px rgba(0, 0, 0, 0.14),
+              0 3px 14px 2px rgba(0, 0, 0, 0.12);
+}
+
+.cdk-drag-animating {
+  transition: transform 250ms cubic-bezier(0, 0, 0.2, 1);
+}
+
+.example-box:last-child {
+  border: none;
+}
+
+.example-list.cdk-drop-list-dragging .example-box:not(.cdk-drag-placeholder) {
+  transition: transform 250ms cubic-bezier(0, 0, 0.2, 1);
+}
+
+.example-custom-placeholder {
+  background: #ccc;
+  border: dotted 3px #999;
+  min-height: 60px;
+  transition: transform 250ms cubic-bezier(0, 0, 0.2, 1);
+}

--- a/src/lib/entity/detail/sz-entity-detail-graph/sz-entity-detail-graph-filter.component.scss
+++ b/src/lib/entity/detail/sz-entity-detail-graph/sz-entity-detail-graph-filter.component.scss
@@ -66,6 +66,38 @@
     }
   }
   ul.colors-list, ul.other-colors-list  {
+    max-width: 100%;
+    display: block;
+    overflow: hidden;
+
+    .color-box {
+      /* padding: 20px 10px; */
+      /* border-bottom: solid 1px #ccc; */
+      display: flex;
+      position: relative;
+      flex-direction: row;
+      align-items: center;
+      justify-content: space-between;
+      box-sizing: border-box;
+    }
+    .color-box-handle {
+      position: absolute;
+      top: 10px;
+      right: 10px;
+      color: #ccc;
+      cursor: move;
+      width: 24px;
+      height: 24px;
+    }
+    .color-box-placeholder {
+      /*background: rgb(250, 250, 250);*/
+      min-height: 26px;
+      border-top: solid 1px #dadada;
+      border-bottom: solid 1px #dadada;
+      height: 2px;
+      transition: transform 250ms cubic-bezier(0, 0, 0.2, 1);
+    }
+
     li {
       margin-bottom: 2px;
       padding-bottom: 0;
@@ -149,54 +181,39 @@
   opacity: 1;
 }
 
-.example-list {
-  width: 500px;
-  max-width: 100%;
-  border: solid 1px #ccc;
-  min-height: 60px;
-  display: block;
-  background: white;
-  border-radius: 4px;
-  overflow: hidden;
-}
-
-.example-box {
-  padding: 20px 10px;
-  border-bottom: solid 1px #ccc;
-  color: rgba(0, 0, 0, 0.87);
+.cdk-drag-preview {
+  background-color: #ccc;
+  opacity: .4;
   display: flex;
   flex-direction: row;
   align-items: center;
   justify-content: space-between;
   box-sizing: border-box;
-  cursor: move;
-  background: white;
-  font-size: 14px;
-}
-
-.cdk-drag-preview {
+  /*border: 2px solid blueviolet;*/
   box-sizing: border-box;
-  border-radius: 4px;
   box-shadow: 0 5px 5px -3px rgba(0, 0, 0, 0.2),
               0 8px 10px 1px rgba(0, 0, 0, 0.14),
               0 3px 14px 2px rgba(0, 0, 0, 0.12);
+  input[type=color] {
+    border-color: #676767;
+    border-image: none;
+    border-radius: 3px;
+    border-width: 2px;
+    cursor: pointer;
+    display: inline-block;
+    gap: revert;
+    height: 14px;
+    margin: 0 7px 0 0;
+    padding: 0 7px ;
+    text-decoration: none;
+    width: 0px;
+  }
 }
 
 .cdk-drag-animating {
   transition: transform 250ms cubic-bezier(0, 0, 0.2, 1);
 }
 
-.example-box:last-child {
-  border: none;
-}
-
-.example-list.cdk-drop-list-dragging .example-box:not(.cdk-drag-placeholder) {
-  transition: transform 250ms cubic-bezier(0, 0, 0.2, 1);
-}
-
-.example-custom-placeholder {
-  background: #ccc;
-  border: dotted 3px #999;
-  min-height: 60px;
+.color-list.cdk-drop-list-dragging .color-box:not(.cdk-drag-placeholder) {
   transition: transform 250ms cubic-bezier(0, 0, 0.2, 1);
 }

--- a/src/lib/entity/detail/sz-entity-detail-graph/sz-entity-detail-graph-filter.component.ts
+++ b/src/lib/entity/detail/sz-entity-detail-graph/sz-entity-detail-graph-filter.component.ts
@@ -45,7 +45,6 @@ export class SzEntityDetailGraphFilterComponent implements OnInit, AfterViewInit
   @Input() showDataSources: string[];
   @Input() dataSourcesFiltered: string[] = [];
   @Input() queriedEntitiesColor: string;
-  public _datasources: string[] = [];
   private _datasourcesFull: SzDataSourceComposite[] = [];
   private _dataSourceColors: SzDataSourceComposite[] = [];
   @Input() set dataSourceColors(value: SzDataSourceComposite[]) {
@@ -209,27 +208,12 @@ export class SzEntityDetailGraphFilterComponent implements OnInit, AfterViewInit
 
   /** handler for when a filter by datasouce value in the "filterByDataSourcesForm" has changed */
   onDsFilterChange(dsValue: string, evt?) {
-    let checkedValue      = evt && !evt.checked ? false : true;
-    let _dsIndex          = this._datasourcesFull.findIndex( (ds: SzDataSourceComposite) => {
-      return ds.name === dsValue;
-    });
-    /*
-    if(_dsIndex >= 0 && this._datasourcesFull[_dsIndex]) {
-      // update item
-      this._datasourcesFull[_dsIndex].hidden = !checkedValue;
-    }*/
-    
-    console.warn('onDsFilterChange: ', checkedValue, evt.target.value, this.dataSourcesOrdered, this._datasourcesFull);
-
-
-    /*
     const filteredDataSourceNames = this.filterByDataSourcesForm.value.datasources
-      .map((v, i) => v ? null : this._datasources[i])
+      .map((v, i) => v ? null : this.dataSourcesOrdered[i].name)
       .filter(v => v !== null);
     // update filters pref
     this.prefs.graph.dataSourcesFiltered = filteredDataSourceNames;
-    //console.log('onDsFilterChange: ', filteredDataSourceNames, this.prefs.graph.dataSourcesFiltered);
-    */
+    console.log('onDsFilterChange: ', filteredDataSourceNames, this.prefs.graph.dataSourcesFiltered);
   }
   /**
    * method for getting the selected pref color for a datasource 
@@ -455,6 +439,7 @@ export class SzEntityDetailGraphFilterComponent implements OnInit, AfterViewInit
   /** initializes filter form controls */
   private initializeDataSourceFormControls() {
     this.getDataSources().subscribe((dataSrc: string[]) => {
+      // this._datasources = dataSrc;
       // lets create a quick lookup map
       let _datasourceColorsMap  = {};
       if(this.dataSourceColorsOrdered) {
@@ -485,7 +470,7 @@ export class SzEntityDetailGraphFilterComponent implements OnInit, AfterViewInit
       // init form controls for filter by datasource
       //console.log('@senzing/sdk-components-ng/sz-entity-detail-graph-filter.initializeDataSourceFormControls(): ', dataSrc, this._datasourcesFull);
       
-      this._datasourcesFull.forEach((o, i) => {
+      this.dataSourcesOrdered.forEach((o, i) => {
         const dsFilterVal = !(this.dataSourcesFiltered.indexOf(o.name) >= 0);
         const control1 = new FormControl(dsFilterVal); // if first item set to true, else false
         // add control for filtered by list

--- a/src/lib/entity/detail/sz-entity-detail-graph/sz-entity-detail-graph-filter.component.ts
+++ b/src/lib/entity/detail/sz-entity-detail-graph/sz-entity-detail-graph-filter.component.ts
@@ -35,6 +35,14 @@ export class SzEntityDetailGraphFilterComponent implements OnInit, AfterViewInit
   isOpen: boolean = true;
   /** subscription to notify subscribers to unbind */
   public unsubscribe$ = new Subject<void>();
+  /** private list of datasource records augmented by SzDataSourceComposite shape 
+   * @internal
+  */
+  private _dataSources: SzDataSourceComposite[]       = [];
+  /** private list of SzDataSourceComposite as stored in local storage 
+   * @internal
+  */
+  private _dataSourceColors: SzDataSourceComposite[]  = [];
 
   @Input() maxDegreesOfSeparation: number = 1;
   @Input() showMaxDegreesOfSeparation: boolean = false;
@@ -46,16 +54,18 @@ export class SzEntityDetailGraphFilterComponent implements OnInit, AfterViewInit
   @Input() showDataSources: string[];
   @Input() dataSourcesFiltered: string[] = [];
   @Input() queriedEntitiesColor: string;
-  
-  private _datasourcesFull: SzDataSourceComposite[] = [];
-  private _dataSourceColors: SzDataSourceComposite[] = [];
+
+  /** 
+   * set the internal list of datasource colors from local storage or input value
+   * and update any changed members also present in "_dataSources" with 
+   * current properties
+   */
   @Input() set dataSourceColors(value: SzDataSourceComposite[]) {
     // update value
     this._dataSourceColors  = value;
-
     // update any values in composites list
-    if(this._datasourcesFull && this._datasourcesFull.map) {
-      let tempDsFull = this._datasourcesFull.map( (dsVal: SzDataSourceComposite) => {
+    if(this._dataSources && this._dataSources.map) {
+      let tempDsFull = this._dataSources.map( (dsVal: SzDataSourceComposite) => {
         // check to see if datasource has entry in value
         let dsColorValueByName = value.find((dsColorValue: SzDataSourceComposite) => {
           return dsColorValue.name === dsVal.name;
@@ -66,20 +76,18 @@ export class SzEntityDetailGraphFilterComponent implements OnInit, AfterViewInit
         }
         return dsVal;
       });
-      this._datasourcesFull = tempDsFull;
-      console.warn('set dataSourceColors: ', this._datasourcesFull, tempDsFull, value);
+      this._dataSources = tempDsFull;
     }
   }
+  /** get list of  "SzDataSourceComposite" reflecting current state of datasource colors and order. ordered ASC by "index" */
   get dataSourceColors(): SzDataSourceComposite[] {
-    return this._dataSourceColors;
-  }
-  public get dataSourceColorsOrdered(): SzDataSourceComposite[] {
-    let retVal: SzDataSourceComposite[] = this._datasourcesFull;
+    let retVal: SzDataSourceComposite[] = this._dataSources;
     retVal = sortDataSourcesByIndex(retVal);
     return retVal;
-  };
-  public get dataSourcesOrdered(): SzDataSourceComposite[] {
-    let retVal: SzDataSourceComposite[] = this._datasourcesFull;
+  }
+  /** get list of  "SzDataSourceComposite" reflecting datasources pulled from API and augmented with state information in shape of "SzDataSourceComposite". ordered ASC by "index" */
+  public get dataSources(): SzDataSourceComposite[] {
+    let retVal: SzDataSourceComposite[] = this._dataSources;
     retVal = sortDataSourcesByIndex(retVal);
     return retVal;
   }
@@ -106,7 +114,6 @@ export class SzEntityDetailGraphFilterComponent implements OnInit, AfterViewInit
   @HostBinding('class.not-showing-link-labels') public get hidingLinkLabels(): boolean {
     return !this._showLinkLabels;
   }
-
 
   // ------------------------------------  getters and setters --------------------------
 
@@ -137,7 +144,7 @@ export class SzEntityDetailGraphFilterComponent implements OnInit, AfterViewInit
 
   constructor(
     public prefs: SzPrefsService,
-    public datasources: SzDataSourcesService,
+    public dataSourcesService: SzDataSourcesService,
     private formBuilder: FormBuilder,
     private cd: ChangeDetectorRef
   ) {
@@ -169,38 +176,20 @@ export class SzEntityDetailGraphFilterComponent implements OnInit, AfterViewInit
   /** handler for when a filter by datasouce value in the "filterByDataSourcesForm" has changed */
   onDsFilterChange(dsValue: string, evt?) {
     const filteredDataSourceNames = this.filterByDataSourcesForm.value.datasources
-      .map((v, i) => v ? null : this.dataSourcesOrdered[i].name)
+      .map((v, i) => v ? null : this.dataSources[i].name)
       .filter(v => v !== null);
     // update filters pref
     this.prefs.graph.dataSourcesFiltered = filteredDataSourceNames;
-    console.log('onDsFilterChange: ', filteredDataSourceNames, this.prefs.graph.dataSourcesFiltered);
   }
   /**
    * method for getting the selected pref color for a datasource 
    * by the datasource name. used for applying background color to 
    * input[type=color] to make them look fancier
    */
-  /*
-  getDataSourceColorOld(dsValue) {
-    const coloredDataSourceNames = this.colorsByDataSourcesForm.value.datasources
-      .map((v, i) => {
-        const hasColor = v ? true : false;
-        return v ? {'key': this._datasources[i], 'value': v} : null;
-      })
-      .filter(v => v !== null);
-    
-    let dsFormValMatch = coloredDataSourceNames.find( (_keyValPair) => {
-      return _keyValPair.key === dsValue ? true : false;
-    });
-    if(dsFormValMatch) {
-      return dsFormValMatch.value;
-    }
-    return 'transparent';
-  }*/
   getDataSourceColor(dsValue: string) {
     let retVal = null;
-    if(this._datasourcesFull && this._datasourcesFull.find){
-      let dsObj = this._datasourcesFull.find((_ds: SzDataSourceComposite) => {
+    if(this._dataSources && this._dataSources.find){
+      let dsObj = this._dataSources.find((_ds: SzDataSourceComposite) => {
         return _ds.name === dsValue;
       });
       if(dsObj && dsObj.color) {
@@ -211,39 +200,15 @@ export class SzEntityDetailGraphFilterComponent implements OnInit, AfterViewInit
   }
   /** handler for when a color value for a source in the "colorsByDataSourcesForm" has changed */
   onDsColorChange(dsValue: string, src?: any, evt?) {
-    console.log('onDsColorChange: ', src, evt);
     // update color value in array
-    if(this._datasourcesFull) {
-      let _dsIndex = this._datasourcesFull.findIndex((dsVal: SzDataSourceComposite) => {
+    if(this._dataSources) {
+      let _dsIndex = this._dataSources.findIndex((dsVal: SzDataSourceComposite) => {
         return dsVal.name === dsValue;
       });
-      if(_dsIndex && this._datasourcesFull && this._datasourcesFull[ _dsIndex ]) {
-        this._datasourcesFull[ _dsIndex ].color = src.value;
+      if(_dsIndex && this._dataSources && this._dataSources[ _dsIndex ]) {
+        this._dataSources[ _dsIndex ].color = src.value;
       }
     }
-    // update color swatch bg color(for prettier boxes)
-    if(src && src.style && src.style.setProperty){
-      src.style.setProperty('background-color', src.value);
-    }
-    // update colors pref
-    if( this.prefs && this.prefs.graph) {
-      // there is some sort of mem reference clone issue
-      // forcing update seems to fix it
-      this.prefs.graph.dataSourceColors = this.dataSourceColorsOrdered;
-    }
-  }
-  /*
-  onDsColorChangeOld(src?: any, evt?) {
-    const coloredDataSourceNames = this.colorsByDataSourcesForm.value.datasources
-      .map((v, i) => {
-        const hasColor = v ? true : false;
-        return v ? {'key': this._datasources[i], 'value': v} : null;
-      })
-      .filter(v => v !== null);
-
-    coloredDataSourceNames.forEach( (pair) => {
-      this.dataSourceColors[pair.key] = pair.value;
-    });
     // update color swatch bg color(for prettier boxes)
     if(src && src.style && src.style.setProperty){
       src.style.setProperty('background-color', src.value);
@@ -255,7 +220,6 @@ export class SzEntityDetailGraphFilterComponent implements OnInit, AfterViewInit
       this.prefs.graph.dataSourceColors = this.dataSourceColors;
     }
   }
-  */
   /** handler for when an integer pref value has changed. ie: buildOut  */
   onIntParameterChange(prefName, value) {
     if(this.prefs.graph[prefName] !== undefined) {
@@ -288,15 +252,18 @@ export class SzEntityDetailGraphFilterComponent implements OnInit, AfterViewInit
     this.dataSourceColors = prefs.dataSourceColors;
     this.dataSourcesFiltered = prefs.dataSourcesFiltered;
     this.queriedEntitiesColor = prefs.queriedEntitiesColor;
-
-    console.log('@senzing/sdk-components-ng/sz-entity-detail-graph-filter.onPrefsChange(): ', prefs, this.dataSourceColors);
-
+    //console.log('@senzing/sdk-components-ng/sz-entity-detail-graph-filter.onPrefsChange(): ', prefs, this.dataSourceColors);
     // update view manually (for web components redraw reliability)
     this.cd.detectChanges();
   }
 
+  /** 
+   * when user changes the order of a color by dragging it to 
+   * a different position in list update internal list "index"
+   * values and save state to prefs.
+   */
   onColorOrderDrop(event: CdkDragDrop<string[]>) {
-    let displayedList = this.dataSourceColorsOrdered;
+    let displayedList = this.dataSourceColors;
     if(displayedList && displayedList.filter) {
       displayedList = displayedList.filter((dsVal: SzDataSourceComposite) => {
         return this.shouldDataSourceBeDisplayed(dsVal.name);
@@ -306,22 +273,17 @@ export class SzEntityDetailGraphFilterComponent implements OnInit, AfterViewInit
     let itemAtPosition  = displayedList[event.currentIndex];
     if(event && event.item && event.item.data) {
       if(existingItem && event.item.data !== existingItem.name) {
-        let _existingByName = this._datasourcesFull.find( (_ds: SzDataSourceComposite) => {
+        let _existingByName = this._dataSources.find( (_ds: SzDataSourceComposite) => {
           return _ds.name === event.item.data;
-        });
-        console.warn('whaoooo there! hold up. not the right item! ', existingItem, _existingByName);
-        
+        });        
       }
     }
-    console.log('onColorOrderDrop: ', existingItem, itemAtPosition);
     // now update index values after slicing array
-    let _sortedExistingArray  = this.dataSourceColorsOrdered;
-    let newArray              = this.dataSourceColorsOrdered;
+    let newArray              = this.dataSourceColors;
     // value of "0" means they moved up. value of "1" means they moved down
     let direction             = event.currentIndex < event.previousIndex ? 0 : 1;
     // we se this here because it will be bumped if we reference during loop
     let newIndex              = itemAtPosition.index;
-
     newArray = newArray.map((_dsVal: SzDataSourceComposite) => {
       if(direction === 0){
         // moved up
@@ -333,7 +295,6 @@ export class SzEntityDetailGraphFilterComponent implements OnInit, AfterViewInit
         } else {
           // is item
           _dsVal.index = newIndex;
-          console.log('updated item index to '+ _dsVal.index, newArray);
         }
       } else if(direction === 1) {
         //moved down
@@ -349,9 +310,9 @@ export class SzEntityDetailGraphFilterComponent implements OnInit, AfterViewInit
       }
       return _dsVal;
     });
-    let _sortedNewArray       = sortDataSourcesByIndex(newArray);
-    console.log("direction? "+ direction +" | item slice: ", newArray, _sortedExistingArray, _sortedNewArray);
-    console.log('onColorOrderDrop: ', event, newArray);
+    //let _sortedNewArray       = sortDataSourcesByIndex(newArray);
+    //console.log("direction? "+ direction +" | item slice: ", newArray, _sortedExistingArray, _sortedNewArray);
+    //console.log('onColorOrderDrop: ', event, newArray);
   }
 
   /**
@@ -381,56 +342,32 @@ export class SzEntityDetailGraphFilterComponent implements OnInit, AfterViewInit
     }
   }
 
-  movies = [
-    'Episode I - The Phantom Menace',
-    'Episode II - Attack of the Clones',
-    'Episode III - Revenge of the Sith',
-    'Episode IV - A New Hope',
-    'Episode V - The Empire Strikes Back',
-    'Episode VI - Return of the Jedi',
-    'Episode VII - The Force Awakens',
-    'Episode VIII - The Last Jedi',
-    'Episode IX – The Rise of Skywalker'
-  ];
-  drop(event: CdkDragDrop<string[]>) {
-    moveItemInArray(this.movies, event.previousIndex, event.currentIndex);
-  }
-
   /** initializes filter form controls */
   private initializeDataSourceFormControls() {
     this.getDataSources().subscribe((dataSrc: string[]) => {
-      // this._datasources = dataSrc;
       // lets create a quick lookup map
       let _datasourceColorsMap  = {};
-      if(this.dataSourceColorsOrdered) {
-        this.dataSourceColorsOrdered.forEach((_dsObj: SzDataSourceComposite) => {
+      if(this._dataSourceColors && this._dataSourceColors.forEach) {
+        this._dataSourceColors.forEach((_dsObj: SzDataSourceComposite) => {
           _datasourceColorsMap[ _dsObj.name ] = _dsObj;
         });
       }
-      if(this.dataSourceColors && this.dataSourceColors.forEach) {
-        this.dataSourceColors.forEach((_dsObj: SzDataSourceComposite) => {
-          _datasourceColorsMap[ _dsObj.name ] = _dsObj;
-        });
-      } 
-      //console.log('@senzing/sdk-components-ng/sz-entity-detail-graph-filter.initializeDataSourceFormControls(): colormap', this._datasourcesFull, _datasourceColorsMap);
-
-      this._datasourcesFull = dataSrc.map((_dsStr: string) => {
+      // now lets make sure that the current local _dataSources var
+      // is up to date with what came from the api
+      this._dataSources = dataSrc.map((_dsStr: string) => {
         let retVal = {
           name: _dsStr,
           index: 0
         };
-        // 
         // check to see if we have entry for this in prefs
+        // if we do use the state meta data from that(index, color, etc)
         if( _datasourceColorsMap && _datasourceColorsMap[ _dsStr ]) {
           retVal  = _datasourceColorsMap[ _dsStr ];
         }
         return retVal;
       });
-
-      // init form controls for filter by datasource
-      //console.log('@senzing/sdk-components-ng/sz-entity-detail-graph-filter.initializeDataSourceFormControls(): ', dataSrc, this._datasourcesFull);
-      
-      this.dataSourcesOrdered.forEach((o, i) => {
+      // init form controls for filter by datasource      
+      this.dataSources.forEach((o, i) => {
         const dsFilterVal = !(this.dataSourcesFiltered.indexOf(o.name) >= 0);
         const control1 = new FormControl(dsFilterVal); // if first item set to true, else false
         // add control for filtered by list
@@ -442,7 +379,7 @@ export class SzEntityDetailGraphFilterComponent implements OnInit, AfterViewInit
 
   /** helper method for retrieving list of datasources */
   public getDataSources() {
-    return this.datasources.listDataSources();
+    return this.dataSourcesService.listDataSources();
   }
   /** if "showDataSources" array is specified, check that string name is present in list */
   public shouldDataSourceBeDisplayed( dsName: string) {

--- a/src/lib/entity/detail/sz-entity-detail-graph/sz-entity-detail-graph-filter.component.ts
+++ b/src/lib/entity/detail/sz-entity-detail-graph/sz-entity-detail-graph-filter.component.ts
@@ -232,7 +232,9 @@ export class SzEntityDetailGraphFilterComponent implements OnInit, AfterViewInit
   }
 
   onColorOrderDrop(event: CdkDragDrop<string[]>) {
+    console.log('onColorOrderDrop: ', event, this.dataSourceColorsOrdered.map((ds: {datasource: string, color?: string, index?: number}) => { return ds.datasource}).join(','));
     moveItemInArray(this.dataSourceColorsOrdered, event.previousIndex, event.currentIndex);
+    console.log('onColorOrderDrop: ', event, this.dataSourceColorsOrdered.map((ds: {datasource: string, color?: string, index?: number}) => { return ds.datasource}).join(','));
   }
 
   /**

--- a/src/lib/entity/detail/sz-entity-detail-graph/sz-entity-detail-graph-filter.component.ts
+++ b/src/lib/entity/detail/sz-entity-detail-graph/sz-entity-detail-graph-filter.component.ts
@@ -6,6 +6,7 @@ import { Subject } from 'rxjs';
 import { FormBuilder, FormGroup, FormArray, FormControl, Validators } from '@angular/forms';
 import { CdkDragDrop, moveItemInArray } from '@angular/cdk/drag-drop';
 import { SzDataSourceComposite } from '../../../models/data-sources';
+import { sortDataSourcesByIndex } from '../../../common/utils';
 
 /**
  * Control Component allowing UI friendly changes
@@ -45,6 +46,7 @@ export class SzEntityDetailGraphFilterComponent implements OnInit, AfterViewInit
   @Input() showDataSources: string[];
   @Input() dataSourcesFiltered: string[] = [];
   @Input() queriedEntitiesColor: string;
+  
   private _datasourcesFull: SzDataSourceComposite[] = [];
   private _dataSourceColors: SzDataSourceComposite[] = [];
   @Input() set dataSourceColors(value: SzDataSourceComposite[]) {
@@ -73,55 +75,13 @@ export class SzEntityDetailGraphFilterComponent implements OnInit, AfterViewInit
   }
   public get dataSourceColorsOrdered(): SzDataSourceComposite[] {
     let retVal: SzDataSourceComposite[] = this._datasourcesFull;
-    retVal = this.sortDataSourcesByIndex(retVal);
+    retVal = sortDataSourcesByIndex(retVal);
     return retVal;
   };
   public get dataSourcesOrdered(): SzDataSourceComposite[] {
     let retVal: SzDataSourceComposite[] = this._datasourcesFull;
-    retVal = this.sortDataSourcesByIndex(retVal);
+    retVal = sortDataSourcesByIndex(retVal);
     return retVal;
-  }
-
-  private sortDataSourcesByIndex(value: SzDataSourceComposite[]): SzDataSourceComposite[] {
-    let retVal  = value;
-    if(retVal && retVal.sort) {
-      // first sort by any existing indexes
-      retVal = retVal.sort((a, b) => {    
-          if (a.index > b.index) {
-              return 1;
-          } else if (a.index < b.index) {    
-              return -1;
-          } else {
-            // sort by name
-          }
-          return 0;
-      });
-      // now update index values to same as array
-      retVal  = retVal.map((_dsVal: SzDataSourceComposite, _index: number) => {
-        let _reIndexed  = _dsVal;
-        _reIndexed.index = _index;
-        return _reIndexed;
-      });
-    }
-    return retVal;
-  }
-
-  public getOrderedColors():void {
-    let retVal  = "Data Sources:\n\r";
-    let ordered = this.dataSourceColorsOrdered;
-    if(ordered && ordered.forEach) {
-      ordered.forEach( (dsVal: SzDataSourceComposite) => {
-        retVal = retVal + dsVal.index + ': '+ dsVal.name + '\n';
-      });
-    }
-    /*
-    if(this._datasourcesFull && this._datasourcesFull.sort) {
-      this._datasourcesFull.forEach((_dsVal: SzDataSourceComposite) => {
-        retVal  = retVal + _dsVal.index + ': '+ _dsVal.name +'\n';
-      });
-      console.log('getOrderedColors: ', this._datasourcesFull);
-    }*/
-    alert(retVal);
   }
 
   /** show match keys */
@@ -389,7 +349,7 @@ export class SzEntityDetailGraphFilterComponent implements OnInit, AfterViewInit
       }
       return _dsVal;
     });
-    let _sortedNewArray       = this.sortDataSourcesByIndex(newArray);
+    let _sortedNewArray       = sortDataSourcesByIndex(newArray);
     console.log("direction? "+ direction +" | item slice: ", newArray, _sortedExistingArray, _sortedNewArray);
     console.log('onColorOrderDrop: ', event, newArray);
   }

--- a/src/lib/entity/detail/sz-entity-detail-graph/sz-entity-detail-graph.component.ts
+++ b/src/lib/entity/detail/sz-entity-detail-graph/sz-entity-detail-graph.component.ts
@@ -15,6 +15,9 @@ import {
 import { SzEntityDetailGraphControlComponent } from './sz-entity-detail-graph-control.component';
 import { SzNetworkGraphInputs } from '../../../models/network-graph-inputs';
 import { SzRelationshipNetworkComponent, NodeFilterPair } from '@senzing/sdk-graph-components';
+import { sortDataSourcesByIndex } from '../../../common/utils';
+import { SzDataSourceComposite } from '../../../models/data-sources';
+
 /**
  * @internal
  * @export
@@ -36,6 +39,11 @@ export class SzEntityDetailGraphComponent implements OnInit, OnDestroy {
    */
   private _graphComponentRenderCompleted: Subject<boolean> = new Subject<boolean>();
   private _graphComponentRendered = false;
+  /**
+   * list of datasources with color and order information
+   * @internal
+   */
+  private _dataSourceColors: SzDataSourceComposite[] = [];
 
   /**
    * @internal
@@ -101,7 +109,16 @@ export class SzEntityDetailGraphComponent implements OnInit, OnDestroy {
   @Input() maxDegrees: number = 1;
   @Input() maxEntities: number = 20;
   @Input() buildOut: number = 1;
-  @Input() dataSourceColors: any = {};
+  /** array of datasources with color and order information */
+  @Input() public set dataSourceColors(value: SzDataSourceComposite[]) {
+    this._dataSourceColors  = value;
+  }
+  /** array of datasources with color and order information. ordered ASC by index property */
+  public get dataSourceColors(): SzDataSourceComposite[] {
+    let retVal: SzDataSourceComposite[] = this._dataSourceColors;
+    retVal = sortDataSourcesByIndex(retVal);
+    return retVal;
+  };
   @Input() dataSourcesFiltered: string[] = [];
   @Input() showPopOutIcon: boolean = false;
   @Input() showFiltersControl: boolean = false;
@@ -433,7 +450,7 @@ export class SzEntityDetailGraphComponent implements OnInit, OnDestroy {
 
   /** proxy handler for when prefs have changed externally */
   private onPrefsChange(prefs: any) {
-    // console.log('@senzing/sdk-components-ng/sz-entity-detail-graph.onPrefsChange(): ', prefs, this.prefs.graph);
+    //console.log('@senzing/sdk-components-ng/sz-entity-detail-graph.onPrefsChange(): ', prefs, this.prefs.graph);
     let queryParamChanged = false;
     if(this.maxDegrees != prefs.maxDegreesOfSeparation ||
       this.maxEntities != prefs.maxEntities ||
@@ -470,17 +487,16 @@ export class SzEntityDetailGraphComponent implements OnInit, OnDestroy {
   public get entityNodecolorsByDataSource(): NodeFilterPair[] {
     let _ret = [];
     if(this.dataSourceColors) {
-      const _keys = Object.keys(this.dataSourceColors);
-      _ret = _keys.map( (_key) => {
-        const _color = this.dataSourceColors[_key];
+      _ret = this.dataSourceColors.reverse().map((dsVal: SzDataSourceComposite) => {
         return {
-          selectorFn: this.isEntityNodeInDataSource.bind(this, _key),
-          modifierFn: this.setEntityNodeFillColor.bind(this, _color),
-          selectorArgs: _key,
-          modifierArgs: _color
+          selectorFn: this.isEntityNodeInDataSource.bind(this, dsVal.name),
+          modifierFn: this.setEntityNodeFillColor.bind(this, dsVal.color),
+          selectorArgs: dsVal.name,
+          modifierArgs: dsVal.color
         };
       });
     }
+    //console.warn('entityNodecolorsByDataSource: ', _ret);
     return _ret;
   }
   /** get the list of filters to apply to inner graph component */

--- a/src/lib/entity/detail/sz-entity-detail-graph/sz-standalone-graph.component.ts
+++ b/src/lib/entity/detail/sz-entity-detail-graph/sz-standalone-graph.component.ts
@@ -72,6 +72,11 @@ export class SzStandaloneGraphComponent implements OnInit, OnDestroy {
    */
   private _graphComponentRenderCompleted: Subject<boolean> = new Subject<boolean>();
   private _graphComponentRendered = false;
+  /**
+   * list of datasources with color and order information
+   * @internal
+   */
+  private _dataSourceColors: SzDataSourceComposite[] = [];
 
   /**
    * @internal
@@ -106,10 +111,11 @@ export class SzStandaloneGraphComponent implements OnInit, OnDestroy {
   @Input() maxDegrees: number = 1;
   @Input() maxEntities: number = 20;
   @Input() buildOut: number = 1;
-  private _dataSourceColors: SzDataSourceComposite[] = [];
+  /** array of datasources with color and order information */
   @Input() public set dataSourceColors(value: SzDataSourceComposite[]) {
     this._dataSourceColors  = value;
   }
+  /** array of datasources with color and order information. ordered ASC by index property */
   public get dataSourceColors(): SzDataSourceComposite[] {
     let retVal: SzDataSourceComposite[] = this._dataSourceColors;
     retVal = sortDataSourcesByIndex(retVal);
@@ -166,8 +172,6 @@ export class SzStandaloneGraphComponent implements OnInit, OnDestroy {
     return !this._showMatchKeys;
   }
 
-  //@HostBinding('class.open') get cssClssOpen() { return this.expanded; };
-  //@HostBinding('class.closed') get cssClssClosed() { return !this.expanded; };
   @ViewChild('graphContainer') graphContainerEle: ElementRef;
   @ViewChild(SzEntityDetailGraphControlComponent) graphControlComponent: SzEntityDetailGraphControlComponent;
   @ViewChild(SzRelationshipNetworkComponent) graph : SzRelationshipNetworkComponent;
@@ -321,7 +325,7 @@ export class SzStandaloneGraphComponent implements OnInit, OnDestroy {
   }
 
   public onOptionChange(event: {name: string, value: any}) {
-    console.log('onOptionChange: ', event);
+    //console.log('onOptionChange: ', event);
     switch(event.name) {
       case 'showLinkLabels':
         this.showMatchKeys = event.value;
@@ -489,19 +493,6 @@ export class SzStandaloneGraphComponent implements OnInit, OnDestroy {
           modifierArgs: dsVal.color
         };
       });
-
-      /*
-      const _keys = Object.keys(this.dataSourceColors);
-      _ret = _keys.map( (_key) => {
-        const _color = this.dataSourceColors[_key];
-        return {
-          selectorFn: this.isEntityNodeInDataSource.bind(this, true, _key),
-          modifierFn: this.setEntityNodeFillColor.bind(this, _color),
-          selectorArgs: _key,
-          modifierArgs: _color
-        };
-      });
-      */
     }
     return _ret;
   }
@@ -561,28 +552,6 @@ export class SzStandaloneGraphComponent implements OnInit, OnDestroy {
       }
     }
   }
-  /*
-  @deprecated
-  private isEntityNodeInDataSources(dataSources, nodeData) {
-    // console.log('fromOwners: ', nodeData);
-    console.log('isEntityNodeInDataSources: ', dataSources, nodeData);
-    if(this.neverFilterQueriedEntityIds && this.graphIds.indexOf( nodeData.entityId ) >= 0){
-      return false;
-    } else {
-      if(nodeData && nodeData.dataSources && nodeData.dataSources.indexOf){
-        // D3 filter query
-        return (nodeData.dataSources.some( (dsName) => {
-          return dataSources.indexOf(dsName) > -1;
-        }));
-      } else if (nodeData && nodeData.d && nodeData.d.dataSources && nodeData.d.dataSources.indexOf) {
-        return (nodeData.d.dataSources.some( (dsName) => {
-            return dataSources.indexOf(dsName) > -1;
-        }));
-      } else {
-        return false;
-      }
-    }
-  }*/
   private isEntityNodeNotInDataSources(dataSources, nodeData) {
     //console.log('isEntityNodeNotInDataSources: ', dataSources, nodeData);
     if(this.neverFilterQueriedEntityIds && this.graphIds.indexOf( nodeData.entityId ) >= 0){

--- a/src/lib/entity/detail/sz-entity-detail-graph/sz-standalone-graph.component.ts
+++ b/src/lib/entity/detail/sz-entity-detail-graph/sz-standalone-graph.component.ts
@@ -14,7 +14,9 @@ import {
 import { SzEntityDetailGraphControlComponent } from './sz-entity-detail-graph-control.component';
 import { SzEntityDetailGraphFilterComponent } from './sz-entity-detail-graph-filter.component';
 import { SzRelationshipNetworkComponent, NodeFilterPair, SzNetworkGraphInputs } from '@senzing/sdk-graph-components';
-import { parseBool } from '../../../common/utils';
+import { parseBool, sortDataSourcesByIndex } from '../../../common/utils';
+import { SzDataSourceComposite } from '../../../models/data-sources';
+
 /**
  * Embeddable Graph Component
  * used to display a entity and its network relationships
@@ -104,7 +106,16 @@ export class SzStandaloneGraphComponent implements OnInit, OnDestroy {
   @Input() maxDegrees: number = 1;
   @Input() maxEntities: number = 20;
   @Input() buildOut: number = 1;
-  @Input() dataSourceColors: any = {};
+  private _dataSourceColors: SzDataSourceComposite[] = [];
+  @Input() public set dataSourceColors(value: SzDataSourceComposite[]) {
+    this._dataSourceColors  = value;
+  }
+  public get dataSourceColors(): SzDataSourceComposite[] {
+    let retVal: SzDataSourceComposite[] = this._dataSourceColors;
+    retVal = sortDataSourcesByIndex(retVal);
+    return retVal;
+  };
+
   @Input() dataSourcesFiltered: string[] = [];
   /** @internal */
   private _showPopOutIcon = false;
@@ -470,6 +481,16 @@ export class SzStandaloneGraphComponent implements OnInit, OnDestroy {
   public get entityNodecolorsByDataSource(): NodeFilterPair[] {
     let _ret = [];
     if(this.dataSourceColors) {
+      _ret = this.dataSourceColors.reverse().map((dsVal: SzDataSourceComposite) => {
+        return {
+          selectorFn: this.isEntityNodeInDataSource.bind(this, true, dsVal.name),
+          modifierFn: this.setEntityNodeFillColor.bind(this, dsVal.color),
+          selectorArgs: dsVal.name,
+          modifierArgs: dsVal.color
+        };
+      });
+
+      /*
       const _keys = Object.keys(this.dataSourceColors);
       _ret = _keys.map( (_key) => {
         const _color = this.dataSourceColors[_key];
@@ -480,6 +501,7 @@ export class SzStandaloneGraphComponent implements OnInit, OnDestroy {
           modifierArgs: _color
         };
       });
+      */
     }
     return _ret;
   }

--- a/src/lib/models/data-sources.ts
+++ b/src/lib/models/data-sources.ts
@@ -8,5 +8,6 @@ export class SzDataSourceRecordAnalysis {
 export interface SzDataSourceComposite {
   name: string,
   color?: string,
-  index?: number
+  index?: number,
+  hidden?: boolean
 }

--- a/src/lib/models/data-sources.ts
+++ b/src/lib/models/data-sources.ts
@@ -4,3 +4,9 @@ export class SzDataSourceRecordAnalysis {
   recordCount: number;
   recordsWithRecordIdCount: number;
 }
+
+export interface SzDataSourceComposite {
+  name: string,
+  color?: string,
+  index?: number
+}

--- a/src/lib/sdk.material.module.ts
+++ b/src/lib/sdk.material.module.ts
@@ -1,5 +1,6 @@
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { DragDropModule } from '@angular/cdk/drag-drop';
 import { MatInputModule } from '@angular/material/input'
 import { MatBadgeModule } from '@angular/material/badge';
 import { MatBottomSheetModule } from '@angular/material/bottom-sheet';
@@ -19,7 +20,9 @@ import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 
 @NgModule({
   declarations: [],
-  imports: [ NoopAnimationsModule, MatDialogModule, MatBadgeModule, MatBottomSheetModule, MatInputModule, MatTableModule, MatPaginatorModule, MatSortModule, MatSidenavModule, MatButtonModule, MatCheckboxModule, MatToolbarModule, MatTooltipModule, MatMenuModule, MatIconModule, MatGridListModule],
-  exports: [ MatDialogModule, MatBadgeModule, MatBottomSheetModule, MatInputModule, MatTableModule, MatPaginatorModule, MatSortModule, MatSidenavModule, MatButtonModule, MatCheckboxModule, MatToolbarModule, MatTooltipModule, MatMenuModule, MatIconModule, MatGridListModule],
+  imports: [ NoopAnimationsModule, DragDropModule, MatDialogModule, MatBadgeModule, MatBottomSheetModule, MatInputModule, MatTableModule, MatPaginatorModule, MatSortModule, MatSidenavModule, MatButtonModule, MatCheckboxModule, MatToolbarModule, MatTooltipModule, MatMenuModule, MatIconModule, MatGridListModule],
+  exports: [ 
+    DragDropModule, MatDialogModule, MatBadgeModule, MatBottomSheetModule, MatInputModule, MatTableModule, MatPaginatorModule, MatSortModule, MatSidenavModule, MatButtonModule, MatCheckboxModule, MatToolbarModule, MatTooltipModule, MatMenuModule, MatIconModule, MatGridListModule
+  ],
 })
 export class SzSdkMaterialModule { }

--- a/src/lib/services/sz-prefs.service.ts
+++ b/src/lib/services/sz-prefs.service.ts
@@ -1,6 +1,7 @@
 import { Injectable, OnDestroy } from '@angular/core';
 import { Subject, BehaviorSubject, merge, timer } from 'rxjs';
 import { takeUntil, debounce, filter } from 'rxjs/operators';
+import { SzDataSourceComposite } from '../models/data-sources';
 import { SzSearchHistoryFolio, SzSearchHistoryFolioItem, SzSearchParamsFolio } from '../models/folio';
 //import { Configuration as SzRestConfiguration, ConfigurationParameters as SzRestConfigurationParameters } from '@senzing/rest-api-client-ng';
 
@@ -706,11 +707,8 @@ export class SzGraphPrefs extends SzSdkPrefsBase {
   /** @internal */
   private _openInSidePanel: boolean = false;
   /** @internal */
-  private _dataSourceColors = {
-    'owners':'#0088ff'
-  };
-  private _dataSourceColorsOrdered = [
-    {datasource: 'owners', color: '#0088ff', index: 0}
+  private _dataSourceColors: SzDataSourceComposite[] = [
+    {name: 'owners', color: '#0088ff', index: 0}
   ];
   /** @internal */
   private _showMatchKeys: boolean = false;
@@ -768,21 +766,12 @@ export class SzGraphPrefs extends SzSdkPrefsBase {
     if(!this.bulkSet && this._rememberStateOptions) this.prefsChanged.next( this.toJSONObject() );
   }
   /** colors to apply to entity node when belonging to particular datasources */
-  public get dataSourceColors(): any {
+  public get dataSourceColors(): SzDataSourceComposite[] {
     return this._dataSourceColors;
   }
   /** colors to apply to entity node when belonging to particular datasources */
-  public set dataSourceColors(value: any) {
+  public set dataSourceColors(value: SzDataSourceComposite[]) {
     this._dataSourceColors = value;
-    if(!this.bulkSet && this._rememberStateOptions) this.prefsChanged.next( this.toJSONObject() );
-  }
-  /** colors to apply to entity node when belonging to particular datasources */
-  public get dataSourceColorsOrdered(): any {
-    return this._dataSourceColorsOrdered;
-  }
-  /** colors to apply to entity node when belonging to particular datasources */
-  public set dataSourceColorsOrdered(value: any) {
-    this._dataSourceColorsOrdered = value;
     if(!this.bulkSet && this._rememberStateOptions) this.prefsChanged.next( this.toJSONObject() );
   }
   /** show match keys/edge labels on relationships */

--- a/src/lib/services/sz-prefs.service.ts
+++ b/src/lib/services/sz-prefs.service.ts
@@ -709,6 +709,9 @@ export class SzGraphPrefs extends SzSdkPrefsBase {
   private _dataSourceColors = {
     'owners':'#0088ff'
   };
+  private _dataSourceColorsOrdered = [
+    {datasource: 'owners', color: '#0088ff', index: 0}
+  ];
   /** @internal */
   private _showMatchKeys: boolean = false;
   /** @internal */
@@ -771,6 +774,15 @@ export class SzGraphPrefs extends SzSdkPrefsBase {
   /** colors to apply to entity node when belonging to particular datasources */
   public set dataSourceColors(value: any) {
     this._dataSourceColors = value;
+    if(!this.bulkSet && this._rememberStateOptions) this.prefsChanged.next( this.toJSONObject() );
+  }
+  /** colors to apply to entity node when belonging to particular datasources */
+  public get dataSourceColorsOrdered(): any {
+    return this._dataSourceColorsOrdered;
+  }
+  /** colors to apply to entity node when belonging to particular datasources */
+  public set dataSourceColorsOrdered(value: any) {
+    this._dataSourceColorsOrdered = value;
     if(!this.bulkSet && this._rememberStateOptions) this.prefsChanged.next( this.toJSONObject() );
   }
   /** show match keys/edge labels on relationships */

--- a/src/public-api.ts
+++ b/src/public-api.ts
@@ -56,7 +56,7 @@ export * from '@senzing/sdk-graph-components';
 export * from './lib/models/folio';
 export { SzBulkDataAnalysis } from './lib/models/data-analysis';
 export { SzBulkLoadStatus } from './lib/models/data-importing';
-export { SzDataSourceRecordAnalysis } from './lib/models/data-sources';
+export { SzDataSourceRecordAnalysis, SzDataSourceComposite } from './lib/models/data-sources';
 
 /** export some members of rest client to ease type use */
 export {


### PR DESCRIPTION
# Pull request questions

## Which issue does this address

resolves #111 

## Why was change needed

When an entity belongs to multiple datasources the entities color would always be the last color assigned to a datasource that it belonged to.

## What does change improve

The datasource color precendent/order can be dragged to reorder(when using the filter control). Datasource colors are stored in *SzDataSourceComposite[]* whose models now include a name/color/index value.


https://user-images.githubusercontent.com/13721038/117600101-2a233980-b100-11eb-8f4d-ba19bdb6f642.mp4

