### PR TITLE
Issue219.awinters.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@senzing/sdk-components-ng",
-  "version": "2.2.2",
+  "version": "2.2.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -2734,9 +2734,9 @@
       }
     },
     "@senzing/rest-api-client-ng": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@senzing/rest-api-client-ng/-/rest-api-client-ng-2.2.0.tgz",
-      "integrity": "sha512-nZvkHmFHXTBUcihKeleQnQyIDWGOBKojv8AIhBSAYUWHf+oPTH2bdn+a0ZJXacyKbduxo3dV4kqZg/NDA2gC+A==",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/@senzing/rest-api-client-ng/-/rest-api-client-ng-2.2.2.tgz",
+      "integrity": "sha512-/EOnCfTjIenTFFqgptdGMTwnNFZZbGQmoED+hIkNXfA3V3WZZ2ahCLZLHlQa91UNHy4xwSI0+xqY6Wz377P//g==",
       "requires": {
         "tslib": "^2.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@senzing/sdk-components-ng",
-  "version": "2.2.2",
+  "version": "2.2.3",
   "scripts": {
     "ng": "ng",
     "start": "ng build @senzing/sdk-components-ng && ng serve",
@@ -21,6 +21,7 @@
     "package": "cd ./dist/@senzing/sdk-components-ng/ && npm pack",
     "package:web": "cd ./dist/@senzing/sdk-components-web/ && npm pack",
     "postbuild": "node build-sdk.js && npm run package",
+    "postbuild:web": "node build-web.js && npm run package:web",
     "postinstall": "npm run build",
     "publish": "cd ./dist/@senzing/sdk-components-ng/ && npm publish --access public",
     "publish:web": "cd ./dist/@senzing/sdk-components-web/ && npm publish --access public",
@@ -34,6 +35,7 @@
     "lint": "ng lint @senzing/sdk-components-ng",
     "e2e": "ng e2e e2e-harness --configuration=e2e --protractor-config=e2e/protractor.conf.js",
     "e2e:headless": "ng e2e e2e-harness --configuration=e2e --protractor-config=e2e/protractor.ci.conf.js",
+    "example:aws-amplify-cognito": "ng serve @senzing/sdk-components-ng/examples/aws-amplify-cognito",
     "example:graph": "ng serve @senzing/sdk-components-ng/examples/graph",
     "example:search-by-id": "ng serve @senzing/sdk-components-ng/examples/search-by-id",
     "example:search-in-graph": "ng serve @senzing/sdk-components-ng/examples/search-in-graph",
@@ -57,7 +59,7 @@
     "@angular/platform-browser": "~10.0.9",
     "@angular/platform-browser-dynamic": "~10.0.9",
     "@angular/router": "~10.0.9",
-    "@senzing/rest-api-client-ng": "^2.2.0",
+    "@senzing/rest-api-client-ng": "file:../rest-api-client-ng/dist/@senzing/rest-api-client-ng/senzing-rest-api-client-ng-2.2.2.tgz",
     "@senzing/sdk-graph-components": "^2.1.3",
     "d3": "^5.9.1",
     "document-register-element": "^1.14.5",

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "@angular/platform-browser": "~10.0.9",
     "@angular/platform-browser-dynamic": "~10.0.9",
     "@angular/router": "~10.0.9",
-    "@senzing/rest-api-client-ng": "file:../rest-api-client-ng/dist/@senzing/rest-api-client-ng/senzing-rest-api-client-ng-2.2.2.tgz",
+    "@senzing/rest-api-client-ng": "^2.2.2",
     "@senzing/sdk-graph-components": "^2.1.3",
     "d3": "^5.9.1",
     "document-register-element": "^1.14.5",

--- a/sdk-components-web/package.json
+++ b/sdk-components-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@senzing/sdk-components-web",
-  "version": "2.2.1",
+  "version": "2.2.3",
   "private": false,
   "keywords" :["WebComponent","Library","Senzing"],
   "license" : "SEE LICENSE IN LICENSE",

--- a/src/lib/configuration/sz-configuration/sz-configuration.component.ts
+++ b/src/lib/configuration/sz-configuration/sz-configuration.component.ts
@@ -1,4 +1,4 @@
-import { Component, Inject, Input, Output } from '@angular/core';
+import { Component, Input, Output } from '@angular/core';
 import { Configuration as SzRestConfiguration } from '@senzing/rest-api-client-ng';
 import { Subject } from 'rxjs';
 import { SzConfigurationService } from '../../services/sz-configuration.service';
@@ -80,6 +80,36 @@ export class SzConfigurationComponent {
   @Input()
   set withCredentials(value: boolean) {
     this.apiConfigService.withCredentials = value;
+    this.onParameterChange();
+  }
+
+  /** 
+   * set additional http/https request headers to be added by default to 
+   * all outbound api server requests. most commonly used for adding custom 
+   * or required non-standard headers like jwt session tokens, auth id etc.
+   */
+  @Input()
+  set additionalHeaders(value: {[key: string]: string} | string) {
+    if((value as string).indexOf && (value as string).indexOf(',') > -1) {
+      // assume string in format of "key=value,key=value"
+      try{
+        let _additionalHeaders = {};
+        let _pairs =  (value as string).split(',');
+        if(_pairs && _pairs.forEach) {
+          _pairs.forEach((_pair)=>{
+            let _pairAsArr = _pair.split('=').map((tok) => {
+              return (tok && tok.trim) ?  tok.trim() : tok;
+            });
+            if(_pairAsArr && _pairAsArr.length >= 2) {
+              _additionalHeaders[ _pairAsArr[0] ] = _pairAsArr[1];
+            }
+          });
+        }
+      }catch(err){}
+    } else {
+      // assume object with key-value pairs
+      this.apiConfigService.additionalApiRequestHeaders = (value as {[key: string]: string});
+    }
     this.onParameterChange();
   }
 

--- a/src/lib/configuration/sz-preferences/sz-preferences.component.ts
+++ b/src/lib/configuration/sz-preferences/sz-preferences.component.ts
@@ -1,8 +1,7 @@
-import { Component, Inject, Input, Output, OnInit, OnDestroy, EventEmitter } from '@angular/core';
+import { Component, Input, Output, OnInit, OnDestroy, EventEmitter } from '@angular/core';
 import { Configuration as SzRestConfiguration } from '@senzing/rest-api-client-ng';
 import { Subject } from 'rxjs';
-// import { SzConfigurationService } from '../../services/sz-configuration.service';
-import { SzDataSourcesService } from '../..//services/sz-datasources.service';
+import { SzDataSourcesService } from '../../services/sz-datasources.service';
 import { SzSdkPrefsModel, SzPrefsService } from '../../services/sz-prefs.service';
 import { takeUntil } from 'rxjs/operators';
 

--- a/src/lib/entity/detail/sz-entity-detail-graph/sz-entity-detail-graph-control.component.ts
+++ b/src/lib/entity/detail/sz-entity-detail-graph/sz-entity-detail-graph-control.component.ts
@@ -1,6 +1,5 @@
-import { Component, HostBinding, Input, OnInit, OnDestroy, Output, EventEmitter } from '@angular/core';
+import { Component, Input, OnInit, OnDestroy, Output, EventEmitter } from '@angular/core';
 import { SzPrefsService } from '../../../services/sz-prefs.service';
-import { tap, takeUntil } from 'rxjs/operators';
 import { Subject } from 'rxjs';
 
 /**

--- a/src/lib/entity/detail/sz-entity-detail-graph/sz-entity-detail-graph-filter.component.ts
+++ b/src/lib/entity/detail/sz-entity-detail-graph/sz-entity-detail-graph-filter.component.ts
@@ -1,7 +1,7 @@
 import { Component, HostBinding, Input, OnInit, AfterViewInit, OnDestroy, Output, EventEmitter, ChangeDetectorRef } from '@angular/core';
 import { SzPrefsService, SzSdkPrefsModel } from '../../../services/sz-prefs.service';
 import { SzDataSourcesService } from '../../../services/sz-datasources.service';
-import { tap, takeUntil } from 'rxjs/operators';
+import { takeUntil } from 'rxjs/operators';
 import { Subject } from 'rxjs';
 import { FormBuilder, FormGroup, FormArray, FormControl, Validators } from '@angular/forms';
 

--- a/src/lib/entity/detail/sz-entity-detail-graph/sz-entity-detail-graph.component.ts
+++ b/src/lib/entity/detail/sz-entity-detail-graph/sz-entity-detail-graph.component.ts
@@ -486,7 +486,7 @@ export class SzEntityDetailGraphComponent implements OnInit, OnDestroy {
   /** function used to generate entity node fill colors from those saved in preferences */
   public get entityNodecolorsByDataSource(): NodeFilterPair[] {
     let _ret = [];
-    if(this.dataSourceColors) {
+    if(this.dataSourceColors && this.dataSourceColors.reverse) {
       _ret = this.dataSourceColors.reverse().map((dsVal: SzDataSourceComposite) => {
         return {
           selectorFn: this.isEntityNodeInDataSource.bind(this, dsVal.name),
@@ -495,6 +495,9 @@ export class SzEntityDetailGraphComponent implements OnInit, OnDestroy {
           modifierArgs: dsVal.color
         };
       });
+    } else if(this.dataSourceColors) {
+      // somethings not right, maybe old format
+      console.warn('datasource colors not in correct format', this.dataSourceColors);
     }
     //console.warn('entityNodecolorsByDataSource: ', _ret);
     return _ret;

--- a/src/lib/entity/detail/sz-entity-detail-graph/sz-standalone-graph.component.ts
+++ b/src/lib/entity/detail/sz-entity-detail-graph/sz-standalone-graph.component.ts
@@ -484,7 +484,7 @@ export class SzStandaloneGraphComponent implements OnInit, OnDestroy {
   /** function used to generate entity node fill colors from those saved in preferences */
   public get entityNodecolorsByDataSource(): NodeFilterPair[] {
     let _ret = [];
-    if(this.dataSourceColors) {
+    if(this.dataSourceColors && this.dataSourceColors.reverse) {
       _ret = this.dataSourceColors.reverse().map((dsVal: SzDataSourceComposite) => {
         return {
           selectorFn: this.isEntityNodeInDataSource.bind(this, true, dsVal.name),
@@ -493,6 +493,9 @@ export class SzStandaloneGraphComponent implements OnInit, OnDestroy {
           modifierArgs: dsVal.color
         };
       });
+    } else if(this.dataSourceColors) {
+      // somethings not right, maybe old format
+      console.warn('datasource colors not in correct format', this.dataSourceColors);
     }
     return _ret;
   }

--- a/src/lib/entity/detail/sz-entity-details-section/collapsible-card.component.ts
+++ b/src/lib/entity/detail/sz-entity-details-section/collapsible-card.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, Input, Output, EventEmitter, OnInit, OnDestroy, AfterViewInit, ViewChild, ChangeDetectorRef } from '@angular/core';
+import { Component, Input, Output, EventEmitter, OnInit, OnDestroy, ViewChild, ChangeDetectorRef } from '@angular/core';
 import { SzEntityDetailSectionData } from '../../../models/entity-detail-section-data';
 import { SzEntityRecord } from '@senzing/rest-api-client-ng';
 import { SzPrefsService } from '../../../services/sz-prefs.service';

--- a/src/lib/entity/detail/sz-entity-details-section/header.component.ts
+++ b/src/lib/entity/detail/sz-entity-details-section/header.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, Input, OnInit } from '@angular/core';
+import { Component, Input, OnInit } from '@angular/core';
 
 /**
  * @internal

--- a/src/lib/entity/detail/sz-entity-details-section/sz-entity-details-section.component.ts
+++ b/src/lib/entity/detail/sz-entity-details-section/sz-entity-details-section.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, Input, Output, EventEmitter, OnInit, AfterViewInit, ViewChildren, QueryList, OnDestroy } from '@angular/core';
+import { Component, Input, Output, EventEmitter, ViewChildren, QueryList, OnDestroy } from '@angular/core';
 import { SzRelatedEntity, SzEntityRecord } from '@senzing/rest-api-client-ng';
 import { SzEntityDetailSectionCollapsibleCardComponent } from './collapsible-card.component';
 import { Subject } from 'rxjs';

--- a/src/lib/entity/sz-entity-match-pill/sz-entity-match-pill.component.ts
+++ b/src/lib/entity/sz-entity-match-pill/sz-entity-match-pill.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, Input, OnInit } from '@angular/core';
+import { Component, Input, OnInit } from '@angular/core';
 
 /**
  * @internal

--- a/src/lib/entity/sz-entity-record-card/sz-entity-record-card-content/sz-entity-record-card-content.component.ts
+++ b/src/lib/entity/sz-entity-record-card/sz-entity-record-card-content/sz-entity-record-card-content.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, ChangeDetectorRef, Component, ElementRef, Input, OnInit, ViewChild } from '@angular/core';
+import { ChangeDetectorRef, Component, ElementRef, Input, OnInit, ViewChild } from '@angular/core';
 import { SzSearchResultEntityData } from '../../../models/responces/search-results/sz-search-result-entity-data';
 import { SzEntityDetailSectionData } from '../../../models/entity-detail-section-data';
 import {
@@ -8,7 +8,7 @@ import {
   SzRelatedEntity
 } from '@senzing/rest-api-client-ng';
 import { Subject, BehaviorSubject } from 'rxjs';
-import { tap, takeUntil } from 'rxjs/operators';
+import { takeUntil } from 'rxjs/operators';
 import { SzPrefsService } from '../../../services/sz-prefs.service';
 
 

--- a/src/lib/entity/sz-entity-record-card/sz-entity-record-card-header/sz-entity-record-card-header.component.ts
+++ b/src/lib/entity/sz-entity-record-card/sz-entity-record-card-header/sz-entity-record-card-header.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, EventEmitter, Input, Output, OnInit, OnDestroy, ChangeDetectorRef, HostListener } from '@angular/core';
+import { Component, EventEmitter, Input, Output, OnInit, OnDestroy, ChangeDetectorRef, HostListener } from '@angular/core';
 import { SzSearchResultEntityData } from '../../../models/responces/search-results/sz-search-result-entity-data';
 import { SzResolvedEntity, SzDataSourceRecordSummary } from '@senzing/rest-api-client-ng';
 import { SzPrefsService } from '../../../services/sz-prefs.service';

--- a/src/lib/models/folio.ts
+++ b/src/lib/models/folio.ts
@@ -1,6 +1,4 @@
 import { SzEntitySearchParams } from './entity-search';
-import { SzPrefsService } from '../services/sz-prefs.service';
-import { Inject } from '@angular/core';
 
 // -----------------------  start base folio classes -------------------------
 /**

--- a/src/lib/models/responces/search-results/raw-data.ts
+++ b/src/lib/models/responces/search-results/raw-data.ts
@@ -1,4 +1,4 @@
-import {SzResponseWithRawData} from '@senzing/rest-api-client-ng';
+//import {SzResponseWithRawData} from '@senzing/rest-api-client-ng';
 
 export interface SzRawData {
   DATA_SOURCE: string;

--- a/src/lib/models/responces/search-results/sz-search-result-entity-data.ts
+++ b/src/lib/models/responces/search-results/sz-search-result-entity-data.ts
@@ -1,5 +1,5 @@
 import { SzRawDataMatches } from './raw-data-matches';
-import { SzResolvedEntity, SzRelatedEntity, SzDataSourceRecordSummary } from '@senzing/rest-api-client-ng';
+import { SzResolvedEntity, SzRelatedEntity } from '@senzing/rest-api-client-ng';
 
 export interface SzSearchResultEntityData {
   // required

--- a/src/lib/record/sz-entity-record-viewer.component.ts
+++ b/src/lib/record/sz-entity-record-viewer.component.ts
@@ -1,8 +1,7 @@
-import { ChangeDetectionStrategy, Component, Input, OnInit } from '@angular/core';
+import { Component, Input } from '@angular/core';
 import {
   SzEntityRecord
 } from '@senzing/rest-api-client-ng';
-import { SzSearchByIdFormParams } from '../search/sz-search/sz-search-by-id.component';
 
 /**
  * A component for displaying the result(s) of the sz-search-by-id component

--- a/src/lib/search/sz-search-result-card/sz-search-result-card-content/sz-search-result-card-content.component.ts
+++ b/src/lib/search/sz-search-result-card/sz-search-result-card-content/sz-search-result-card-content.component.ts
@@ -186,8 +186,6 @@ export class SzSearchResultCardContentComponent implements OnInit, OnDestroy {
       return phoneData;
     }
     return [];
-
-    return addressData.concat(phoneData);
   }
 
   get nameData(): string[] | undefined {

--- a/src/lib/services/sz-admin.service.ts
+++ b/src/lib/services/sz-admin.service.ts
@@ -126,13 +126,10 @@ export class SzAdminService {
     );
   }
   public addDataSources(body?: Body | string, dataSource?: string[], withRaw?: boolean, observe?: 'body', reportProgress?: boolean): Observable<SzDataSourcesResponseData> {
-  //public addDataSources(body?: Body | string, dataSource?: string | string[], withRaw?: boolean, observe?: 'body', reportProgress?: boolean): Observable<SzDataSourcesResponseData> {
-  //public addDataSources(body?: string | Body, dataSource?: string, withRaw?: boolean, observe?: "body", reportProgress?: boolean): Observable<SzDataSourcesResponseData> {
     if (!this.adminEnabled || this.readOnly) {
       throw new Error('admin operation not permitted.');
     }
     return this.configService.addDataSources(body, dataSource, withRaw, observe, reportProgress)
-    //return this.configService.addDataSources(body, dataSource, withRaw, observe, reportProgress)
     .pipe(
       map( (resp: SzDataSourcesResponse) => resp.data )
     );
@@ -153,22 +150,18 @@ export class SzAdminService {
     );*/
   }
   public addEntityTypes(body?: Body2 | string, entityType?: string | string[], entityClass?: string, observe?: 'body', reportProgress?: boolean): Observable<string[]> {
-  //public addEntityTypes(entityTypes: string[], entityClass?: string): Observable<string[]> {
     if (!this.adminEnabled || this.readOnly) {
       throw new Error('admin operation not permitted.');
     }
     return this.configService.addEntityTypes(body, entityType, entityClass, observe, reportProgress)
-    //return this.configService.addEntityTypes(null, entityTypes, entityClass)
     .pipe(
       map( (resp: SzEntityTypesResponse) => resp.data.entityTypes )
     );
   }
   public addEntityTypesForClass(entityClassCode: string, body?: SzEntityTypeDescriptor[] | string, entityType?: string[], observe?: 'body', reportProgress?: boolean): Observable<SzEntityTypesResponseData> {
-  //public addEntityTypesForClass(entityClassCode?: string, body?: string | SzEntityTypeDescriptor[], entityType?: string, observe?: "body", reportProgress?: boolean): Observable<SzEntityTypesResponseData> {
     if (!this.adminEnabled || this.readOnly) {
       throw new Error('admin operation not permitted.');
     }
-    //return this.configService.addEntityTypesForClass(entityClassCode, body, entityType, observe, reportProgress)
     return this.configService.addEntityTypesForClass(entityClassCode, body, entityType, observe, reportProgress)
     .pipe(
       map( (resp: SzEntityTypesResponse) => resp.data )
@@ -254,7 +247,6 @@ export class SzAdminService {
     );
   }
   public analyzeBulkRecords(body: string | Blob | File | { [key: string]: any}[], progressPeriod?: string, observe?: 'body', reportProgress?: boolean): Observable<SzBulkDataAnalysisResponse> {
-  //public analyzeBulkRecords(body: string | Blob, observe?: "body", reportProgress?: boolean): Observable<SzBulkDataAnalysisResponse> {
     if (!this.adminEnabled || this.readOnly) {
       throw new Error('admin operation not permitted.');
     }
@@ -264,7 +256,6 @@ export class SzAdminService {
     );
   }
   public loadBulkRecords(body: string | Blob | File | { [key: string]: any}[], dataSource?: string, mapDataSources?: string, mapDataSource?: string[], entityType?: string, mapEntityTypes?: string, mapEntityType?: string[], progressPeriod?: string, observe?: 'body', reportProgress?: boolean): Observable<SzBulkLoadResponse> {
-  //public loadBulkRecords(body: string | Blob, dataSource?: string, entityType?: string, observe?: "body", reportProgress?: boolean): Observable<SzBulkLoadResponse> {
     if (!this.adminEnabled || this.readOnly) {
       throw new Error('admin operation not permitted.');
     }

--- a/src/lib/services/sz-configuration.service.ts
+++ b/src/lib/services/sz-configuration.service.ts
@@ -36,6 +36,29 @@ import { SzPrefsService } from './sz-prefs.service';
   providedIn: 'root'
 })
 export class SzConfigurationService {
+  /** add an additional header to all outgoing API requests */
+  public addHeaderToApiRequests(header: {[key: string]: string}): void {
+    this.apiConfiguration.addAdditionalRequestHeader( header );
+  }
+  /** remove an additional header from all outgoing API requests */
+  public removeHeaderFromApiRequests(header: {[key: string]: string} | string): void {
+    this.apiConfiguration.removeAdditionalRequestHeader( header );
+  }
+  /** 
+   * additional http/https request headers that will be added by default to 
+   * all outbound api server requests.
+   */
+  public get additionalApiRequestHeaders(): {[key: string]: string} | undefined {
+    return this.apiConfiguration.additionalHeaders;
+  }
+  /** 
+   * set additional http/https request headers to be added by default to 
+   * all outbound api server requests. most commonly used for adding custom 
+   * or required non-standard headers like jwt session tokens, auth id etc.
+   */
+  public set additionalApiRequestHeaders(value: {[key: string]: string} | undefined) {
+    this.apiConfiguration.additionalHeaders = value;
+  }
   /**
    * emmitted when a property has been changed.
    * used mostly for diagnostics.
@@ -46,7 +69,6 @@ export class SzConfigurationService {
   private onParameterChange(): void {
     this.parametersChanged.next(this.apiConfiguration);
   }
-
   /**
    * apiKeys to use when connnecting to Api Server
    */
@@ -58,7 +80,6 @@ export class SzConfigurationService {
     }
     this.onParameterChange();
   }
-
   /**
    * Username to use when using challenge response authentication.
    */
@@ -70,7 +91,6 @@ export class SzConfigurationService {
     }
     this.onParameterChange();
   }
-
   /** password used for challenge respose. */
   @Input()
   set password(value: string) {
@@ -80,7 +100,6 @@ export class SzConfigurationService {
     }
     this.onParameterChange();
   }
-
   @Input()
   set accessToken(value: string | (() => string)) {
     this.apiConfiguration.accessToken = value;
@@ -89,7 +108,6 @@ export class SzConfigurationService {
     }
     this.onParameterChange();
   }
-
   /** prefix all api requests with this value. most commonly a http or https
    * protocol://hostname:port string that your api server can be accessed through
    */
@@ -104,7 +122,6 @@ export class SzConfigurationService {
   public get basePath(): string {
     return this.apiConfiguration.basePath;
   }
-
   /** whether or not to use CORs for api requests */
   @Input()
   set withCredentials(value: boolean) {
@@ -114,7 +131,6 @@ export class SzConfigurationService {
     }
     this.onParameterChange();
   }
-
   /** bulk runtime set of sdk configuration */
   public fromParameters(value: SzRestConfigurationParameters) {
     const propKeys = Object.keys(value);

--- a/src/lib/services/sz-entitytypes.service.ts
+++ b/src/lib/services/sz-entitytypes.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, Output, EventEmitter } from '@angular/core';
+import { Injectable } from '@angular/core';
 
 import {
   EntityDataService,
@@ -12,7 +12,7 @@ import {
   SzDataSourcesResponseData
 } from '@senzing/rest-api-client-ng';
 import { Observable } from 'rxjs';
-import { tap, map } from 'rxjs/operators';
+import { map } from 'rxjs/operators';
 
 /**
  * Provides access to the /entitytypes api path.

--- a/src/lib/services/sz-pdf-util.service.ts
+++ b/src/lib/services/sz-pdf-util.service.ts
@@ -1,21 +1,13 @@
 import { Injectable } from '@angular/core';
 import { TitleCasePipe } from '@angular/common';
-import { Observable, fromEventPattern, Subject } from 'rxjs';
-import { map, tap, mapTo } from 'rxjs/operators';
 import { jsPDF } from 'jspdf';
 import html2canvas from 'html2canvas';
 
 import {
-  EntityDataService,
-  ConfigService,
-  SzAttributeSearchResponse,
-  SzEntityData,
-  SzAttributeTypesResponse,
-  SzAttributeType,
   SzAttributeSearchResult
 } from '@senzing/rest-api-client-ng';
 import { SzEntitySearchParams } from '../models/entity-search';
-import { SzEntityDetailComponent } from '../entity/detail/sz-entity-detail.component';
+
 /**
  * Utility service for creating and manipulating PDF files from components and models.
  *
@@ -26,9 +18,8 @@ import { SzEntityDetailComponent } from '../entity/detail/sz-entity-detail.compo
 })
 export class SzPdfUtilService {
   constructor(
-    private entityDataService: EntityDataService,
-    private titleCasePipe: TitleCasePipe,
-    private configService: ConfigService) {}
+    private titleCasePipe: TitleCasePipe
+  ) {}
 
   /**
    * Create a downloadable PDF from an HTMLElement node. Uses canvas as an intermediary.

--- a/src/lib/services/sz-prefs.service.ts
+++ b/src/lib/services/sz-prefs.service.ts
@@ -1,8 +1,7 @@
 import { Injectable, OnDestroy } from '@angular/core';
 import { Subject, BehaviorSubject, merge, timer } from 'rxjs';
-import { takeUntil, debounce, filter } from 'rxjs/operators';
+import { takeUntil, debounce } from 'rxjs/operators';
 import { SzSearchHistoryFolio, SzSearchHistoryFolioItem, SzSearchParamsFolio } from '../models/folio';
-//import { Configuration as SzRestConfiguration, ConfigurationParameters as SzRestConfigurationParameters } from '@senzing/rest-api-client-ng';
 
 /**
  * preferences bus base class. provides common methods for

--- a/src/lib/services/sz-search.service.ts
+++ b/src/lib/services/sz-search.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@angular/core';
-import { Observable, fromEventPattern, Subject } from 'rxjs';
-import { map, tap, mapTo } from 'rxjs/operators';
+import { Observable, Subject } from 'rxjs';
+import { map, tap } from 'rxjs/operators';
 
 import {
   EntityDataService,
@@ -105,16 +105,6 @@ export class SzSearchService {
     this.currentSearchResults = null;
   }
 
-  /*
-  loadSearchResults(queryParams: SzEntitySearchParams, projectId: number): void {
-    //this.store.dispatch(new Search.LoadSearchResultsAction({queryParams, projectId}));
-  }
-
-  loadSearchResultsByAttributes(queryParams: SzEntitySearchParams, projectId: number): void {
-    //this.store.dispatch(new Search.LoadSearchResultsByAttributesAction({queryParams, projectId}));
-  }
-  */
-
   /**
    * @alias getAttributeTypes
   */
@@ -143,7 +133,6 @@ export class SzSearchService {
   public getEntityById(entityId: number, withRelated = false): Observable<SzEntityData> {
     console.log('@senzing/sdk/services/sz-search[getEntityById('+ entityId +', '+ withRelated +')] ');
     const withRelatedStr = withRelated ? 'FULL' : 'NONE';
-    //return this.entityDataService.getEntityByEntityId(entityId, featureMo, forceMini, withFeatu, withDeriv, withRelated?: 'NONE' | 'PARTIAL' | 'FULL', withRaw?: boolean, observe?: 'body', reportProgress?: boolean): Observable<SzEntityResponse>;
     return this.entityDataService.getEntityByEntityId(entityId, undefined, undefined, undefined, undefined, withRelatedStr)
     .pipe(
       tap((res: SzEntityResponse) => console.log('SzSearchService.getEntityById: ' + entityId, res.data)),

--- a/src/package.json
+++ b/src/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@senzing/sdk-components-ng",
-  "version": "2.2.2",
+  "version": "2.2.3",
   "private": false,
   "keywords" :["Angular","Library","Senzing"],
   "license" : "SEE LICENSE IN LICENSE",


### PR DESCRIPTION
# Pull request questions

## Which issue does this address

related #219

## Why was change needed

To facilitate the _option_ for implementations to pass additional HTTP headers to API Server endpoints.

## What does change improve

Passing additional or custom headers are necessary in certain operation scenario's, ie: passing `X-Amz-Security-Token` to a [Cognito](https://aws.amazon.com/cognito/) enabled [API Gateway](https://aws.amazon.com/api-gateway/) address after user authentication.

## Technical Details

- Methods added to SzConfigurationService :
  - addHeaderToApiRequests
  - removeHeaderFromApiRequests
- Accessors added to SzConfigurationService :
  - additionalApiRequestHeaders
- @Input() Accessor added to SzConfigurationComponent : 
  - additionalHeaders
- Code Cleanup (various commented out or unused variables removed)
- Bugfix for #111 (found while checking integration)