### PR TITLE
#279 fix for multi-select effect being present even when multi-select…

### DIFF
--- a/src/lib/entity/detail/sz-entity-detail.component.ts
+++ b/src/lib/entity/detail/sz-entity-detail.component.ts
@@ -150,6 +150,12 @@ export class SzEntityDetailComponent implements OnInit, OnDestroy, AfterViewInit
   /** whether or not to show the "why" comparison button for records */
   @Input() set showRecordWhyUtilities(value: boolean) {
     this._showRecordWhyUtilities = value;
+    // we default to selection mode "single" if set to true and selection mode not explicitly set
+    if(value && this._whySelectionMode === SzWhySelectionMode.NONE) {
+      this._whySelectionMode = SzWhySelectionMode.SINGLE;
+    } else if(!value && this._whySelectionMode !== SzWhySelectionMode.NONE) {
+      this._whySelectionMode = SzWhySelectionMode.NONE;
+    }
   }
   /** if "showRecordWhyUtilities" set to true there is a "single-record" select behavior, and a 
    * "multi-select" behavior. possible values are `SINGLE` and `MUTLI`

--- a/src/lib/entity/detail/sz-entity-details-section/collapsible-card.component.html
+++ b/src/lib/entity/detail/sz-entity-details-section/collapsible-card.component.html
@@ -16,7 +16,9 @@
           </svg>
           <span class="collapsible-card__title">{{cardData?.dataSource}}</span>
         </div>
-        <!--isMultiSelect: {{isMultiSelect}}<br/>
+        <!--recordWhyMultiselectActive: {{recordWhyMultiselectActive}}<br/>
+        showWhyUtilities: {{showWhyUtilities}}<br/>
+        isMultiSelect: {{isMultiSelect}}<br/>
         whySelectionMode: {{whySelectionMode}}-->
         <!-- start "entity select control" mechanism -->
         <div #multiSelectButtonWrapper><sz-button-multi-select #multiSelectButton *ngIf="showWhyUtilities && isMultiSelect"
@@ -26,7 +28,7 @@
           aria-hidden="false" 
           aria-label="Select Records for Why comparison"
           text="Why Comparison"
-          [isSelectActive]="showWhyUtilities"
+          [isSelectActive]="recordWhyMultiselectActive"
           selectedItemTypeSingular="record"
           selectedItemTypePlural="records"
           selectedActionVerb="why comparison"
@@ -90,7 +92,7 @@
           [truncateOtherDataAt]="truncateOtherDataInRecordsAt"
           [entity]="_cardData"
           [parentEntity]="cardData"
-          [ngClass]="{'open': expanded, 'selected': isRecordSelected(_cardData), 'select-mode-single': isSingleSelect, 'select-mode-multiple': isMultiSelect}"
+          [ngClass]="{'open': expanded, 'selected': isRecordSelected(_cardData), 'select-mode-single': isSingleSelect, 'select-mode-multiple': isMultiSelect, 'is-selectable': recordWhySelectActive}"
           [whySelectionMode]="whySelectionMode"
           [layoutClasses]="layoutClasses"
           [truncateResults]="truncateResults"

--- a/src/lib/entity/detail/sz-entity-details-section/collapsible-card.component.scss
+++ b/src/lib/entity/detail/sz-entity-details-section/collapsible-card.component.scss
@@ -60,6 +60,7 @@
     margin: auto auto 1em auto;
   }
 
+  
   sz-entity-record-card-content, .sz-entity-record-card-content {
     display: var(--sz-entity-detail-section-record-card-display);
     background-color: var(--sz-entity-detail-section-record-card-background-color);
@@ -73,21 +74,18 @@
       padding: 0;
       border: none;
     }
-    &.selected {
-      border: 1px solid #0c9bf44a;
-      background-color: #f0f8ffcc;
+    &.is-selectable {
+      &.selected {
+        border: 1px solid #0c9bf44a;
+        background-color: #f0f8ffcc;
+      }
     }
   }
 
-  &:hover {
-    color: var(--sz-entity-detail-section-record-card-hover-color);
-    /*
-    sz-entity-record-card-content, .sz-entity-record-card-content { 
+  &.is-selectable {
+    &.select-mode-multiple:hover {
       color: var(--sz-entity-detail-section-record-card-hover-color);
     }
-    sz-entity-record-card-header, .sz-entity-record-card-header {
-
-    }*/
   }
 
   .mat-expansion-panel-header {

--- a/src/lib/entity/detail/sz-entity-details-section/collapsible-card.component.ts
+++ b/src/lib/entity/detail/sz-entity-details-section/collapsible-card.component.ts
@@ -32,10 +32,9 @@ export class SzEntityDetailSectionCollapsibleCardComponent implements OnInit, On
   @Input() public showOtherDataInEntities: boolean = false;
   @Input() public columnsShown: boolean[] = undefined;
   @Input() public showWhyUtilities: boolean = false;
+  @Input() public recordWhyMultiselectActive: boolean = false;
 
-  public recordWhyMultiselectActive: boolean = false;
   private _whySelectionMode: SzWhySelectionModeBehavior = SzWhySelectionMode.NONE;
-
   @Output() onCompareRecordsForWhy = new EventEmitter<SzRecordId[]>();
   /** 
    * if "showRecordWhyUtilities" set to true there is a "single-record" select behavior, and a 
@@ -107,9 +106,11 @@ export class SzEntityDetailSectionCollapsibleCardComponent implements OnInit, On
   get recordCount() {
     return (this.cardData && this.cardData.records) ? this.cardData.records.length : 0;
   }
-
+  /** is responsible for deciding whether or not the 'selected' css class is applied
+   * to the "sz-entity-record-card-content" component
+   */
   public isRecordSelected(value: SzEntityRecord) {
-    if(value.dataSource && value.recordId) {
+    if(this.isMultiSelect && value.dataSource && value.recordId) {
       let dataSources = Object.keys(this._dataSourceRecordsSelected);
       if(dataSources.indexOf(value.dataSource) > -1) {
         // datasource exists, now check for record
@@ -218,29 +219,41 @@ export class SzEntityDetailSectionCollapsibleCardComponent implements OnInit, On
   }
 
   public onEntityRecordClick(entityId: number): void {
-    console.log('sz-entity-detail-section-collapsible-card: ', entityId);
+    //console.log('sz-entity-detail-section-collapsible-card: ', entityId);
     this.entityRecordClick.emit(entityId);
   }
-
+  /** handler is invoked when a "Why" button for a individual record is clicked */
   public onRecordsWhyButtonClick(event: any) {
-    console.log('SzEntityDetailSectionCollapsibleCardComponent.onRecordsWhyButtonClick() ', event);
+    //console.log('SzEntityDetailSectionCollapsibleCardComponent.onRecordsWhyButtonClick() ', event);
     this.onCompareRecordsForWhy.emit([]);
   }
-
+  /** when using the "MULTI" mode record select, the "click-to-select" behavior can be toggled, 
+   * when the icon is clicked to toggle the mode this event is emitted */
+  @Output('dataSourceSelectModeChanged') onDataSourceSelectModeChangedEmitter = new EventEmitter<boolean>();
+  /** when using the "MULTI" mode record select, the "click-to-select" behavior can be toggled, 
+   * when the icon is clicked this handler is invoked */
   public onWhyRecordComparisonModeActiveChange(isActive: boolean) {
-    this.recordWhyMultiselectActive = isActive;
+    this.onDataSourceSelectModeChangedEmitter.emit(isActive);
   }
+  /** are records selectable via a "click" user event */
+  public get recordWhySelectActive() {
+    return this.recordWhyMultiselectActive || this.isSingleSelect;
+  };
+  /** event that is emitted when a data source record is clicked */
   @Output('dataSourceRecordClicked') onDataSourceRecordClickedEmitter = new EventEmitter<SzRecordId>();
+  /** event handler that is invoked when a data source record is clicked */
   public onDataSourceRecordClicked(recordIdentifier: SzRecordId | any) {
-    console.log('sz-entity-detail-section-collapsible-card: ', recordIdentifier);
+    //console.log('sz-entity-detail-section-collapsible-card: ', recordIdentifier);
     this.onDataSourceRecordClickedEmitter.emit(recordIdentifier);
   }
+  /** event that is emitted when a data source records "Why" button is clicked */
   @Output('dataSourceRecordWhyClicked') onDataSourceRecordWhyClickedEmitter = new EventEmitter<SzRecordId>();
+  /** event handler that is invoked when a data source records "Why" button is clicked */
   public onDataSourceRecordWhyClicked(recordIdentifier: SzRecordId | any) {
-    console.log('sz-entity-detail-section-collapsible-card: ', recordIdentifier);
+    //console.log('sz-entity-detail-section-collapsible-card: ', recordIdentifier);
     this.onDataSourceRecordWhyClickedEmitter.emit(recordIdentifier);
   }
-  
+  /** get the user-selected "records" when multi-select "Why" feature is active  */
   public get selectedRecords(): SzRecordId[] {
     let retVal = [];
     let _dataSources = Object.keys(this.dataSourceRecordsSelected);
@@ -253,12 +266,14 @@ export class SzEntityDetailSectionCollapsibleCardComponent implements OnInit, On
     })
     return retVal
   }
-
+  /** @internal  */
   private _dataSourceRecordsSelected: SzDataSourceRecordsSelection = {}
+  /** get the user-selected "records" when multi-select "Why" feature is active  */
   @Input() set dataSourceRecordsSelected(records: SzDataSourceRecordsSelection) {
-    console.log('SzEntityDetailSectionCollapsibleCardComponent setting "dataSourceRecordsSelected"', records);
+    //console.log('SzEntityDetailSectionCollapsibleCardComponent setting "dataSourceRecordsSelected"', records);
     this._dataSourceRecordsSelected = records;
   }
+  /** get the user-selected "records" when multi-select "Why" feature is active  */
   get dataSourceRecordsSelected(): SzDataSourceRecordsSelection {
     return this._dataSourceRecordsSelected;
   }

--- a/src/lib/entity/detail/sz-entity-details-section/sz-entity-details-section.component.html
+++ b/src/lib/entity/detail/sz-entity-details-section/sz-entity-details-section.component.html
@@ -25,7 +25,9 @@
       [dataSourceRecordsSelected]="selectedDataSourceRecords"
       (dataSourceRecordClicked)="onDataSourceRecordClick($event)"
       (dataSourceRecordWhyClicked)="onDataSourceRecordWhyClick($event)"
+      [recordWhyMultiselectActive]="dataSourceIsSelectable"
       [whySelectionMode]="whySelectionMode"
+      (dataSourceSelectModeChanged)="onDataSourceSelectModeChanged($event)"
       (entityRecordClick)="onEntityRecordClick($event)">
     </sz-entity-detail-section-collapsible-card>
   </ng-container>

--- a/src/lib/entity/sz-entity-record-card/sz-entity-record-card-content/sz-entity-record-card-content.component.scss
+++ b/src/lib/entity/sz-entity-record-card/sz-entity-record-card-content/sz-entity-record-card-content.component.scss
@@ -43,23 +43,25 @@
     border-color: var(--sz-entity-detail-section-record-card-why-button-border-color);
   }
 
-  &.select-mode-multiple:hover {
-    cursor: pointer;
-    background-color: #f0f8ffcc;
-
-    .select-mode-multiple-hover-mask {
-      display: inline-block;
+  &.is-selectable {
+    &.select-mode-multiple:hover {
+      cursor: pointer;
+      background-color: #f0f8ffcc;
+  
+      .select-mode-multiple-hover-mask {
+        display: inline-block;
+      }
+      &.selected .select-mode-multiple-hover-mask {
+        display: none;
+      }
     }
-    &.selected .select-mode-multiple-hover-mask {
-      display: none;
-    }
-  }
-  &.select-mode-single:hover {
-    cursor: pointer;
-    background-color: #f0f8ffcc;
-
-    .select-mode-single-hover-button {
-      display: inline-block;
+    &.select-mode-single:hover {
+      /*cursor: pointer;
+      background-color: #f0f8ffcc;*/
+  
+      .select-mode-single-hover-button {
+        display: inline-block;
+      }
     }
   }
 


### PR DESCRIPTION
fix for multi-select effect being present even when multi-select not active

# Pull request questions

## Which issue does this address

resolves #279 

## Why was change needed

When "multi-select" or "single-select" for why on records disabled user could still click each record and the record would toggle a _highlight_ effect on and off. normally during multi-select operations this gives the user visual feedback on which records are selected for "why" comparison.

## What does change improve

when mult-select inactive datasource records no longer have a _hover_ / _highlight_ effect.
