### PR TITLE
Match Key Token Graph Filtering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and [rest api specification](https://github.com/Senzing/senzing-rest-api-specifi
 - The following event emitters to `SzEntityDetailComponent`
   - `recordsWhyButtonClick` - is emitted when a user clicks a why button from within the context of a record.
   - `headerWhyButtonClick` - is emitted when a user clicks a why button underneath the icon in the header.
+- The graph filters found in the `SzStandaloneGraphComponent` can now show a tag cloud of *Match Key Tokens*. If setting the `showMatchKeyTokenFilters="true"` you should also set the `showMatchKeyFilters]="false"` since the two options are exclusive and will interfere with proper function of the other.
 
 ### Removed
 - the following methods removed `SzAdminService`

--- a/examples/search-in-graph/src/app/app.component.html
+++ b/examples/search-in-graph/src/app/app.component.html
@@ -8,7 +8,7 @@
 <!-- start search box -->
 <div class="component-example">
   <sz-search
-    name="Jenny Smith"
+    name="CHARLES SCERRI"
     #searchBox
     disableIdentifierOptions="SSN_LAST4"
     enableIdentifierOptions="SOCIAL_NETWORK"
@@ -47,7 +47,8 @@
         [filterControlPosition]="'top-right'"
         (entityClick)="onGraphEntityClick($event)"
         [showMatchKeys]="true"
-        [showMatchKeyFilters]="true"
+        [showMatchKeyFilters]="false"
+        [showMatchKeyTokenFilters]="true"
         showZoomControl="true"
         (requestStarted)="onRequestStarted($event)"
         (renderComplete)="onRenderComplete($event)"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@senzing/sdk-components-ng",
-  "version": "4.0.0-beta.5",
+  "version": "4.0.0-beta.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -4354,9 +4354,9 @@
       }
     },
     "@senzing/sdk-graph-components": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@senzing/sdk-graph-components/-/sdk-graph-components-4.0.0.tgz",
-      "integrity": "sha512-e5hIdBaKsLrJLVXrVYIFZUsstxX+IVJZdqfpCYnMJztPN7x+4ILe3AE3njofKLr4x5l2EEOS2u1oRBqYnEcWnw==",
+      "version": "4.1.0-beta.1",
+      "resolved": "https://registry.npmjs.org/@senzing/sdk-graph-components/-/sdk-graph-components-4.1.0-beta.1.tgz",
+      "integrity": "sha512-aBQhj4NIRMvepqw+/fMRntyAwmjFDzoPmIQELBsJuCfDTfnfD2mr8AsLcRFgspoED5E4fJr6Lp/0KGDELcROPA==",
       "requires": {
         "tslib": "^2.3.0"
       }
@@ -10842,7 +10842,8 @@
     "node-forge": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.0.tgz",
-      "integrity": "sha512-08ARB91bUi6zNKzVmaj3QO7cr397uiDT2nJ63cHjyNtCTWIgvS47j3eT0WfzUwS9+6Z5YshRaoasFkXCKrIYbA=="
+      "integrity": "sha512-08ARB91bUi6zNKzVmaj3QO7cr397uiDT2nJ63cHjyNtCTWIgvS47j3eT0WfzUwS9+6Z5YshRaoasFkXCKrIYbA==",
+      "dev": true
     },
     "node-gyp": {
       "version": "8.4.1",

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "@angular/platform-browser-dynamic": "~13.2.0",
     "@angular/router": "~13.2.0",
     "@senzing/rest-api-client-ng": "^4.0.0",
-    "@senzing/sdk-graph-components": "^4.0.0",
+    "@senzing/sdk-graph-components": "^4.1.0-beta.1",
     "acorn": "^8.6.0",
     "ajv": "^6.12.6",
     "d3": "^5.9.1",

--- a/src/lib/common/utils.ts
+++ b/src/lib/common/utils.ts
@@ -1,5 +1,5 @@
 import { SzDataSourceComposite } from '../models/data-sources';
-import { SzMatchKeyComposite } from '../models/graph';
+import { SzMatchKeyTokenComposite, SzMatchKeyComposite } from '../models/graph';
 
 /**
  * A reusable function to remove any null or undefined values, and their
@@ -88,6 +88,30 @@ export function sortMatchKeysByIndex(value: SzMatchKeyComposite[]): SzMatchKeyCo
     });
     // now update index values to same as array
     retVal  = retVal.map((_mkVal: SzMatchKeyComposite, _index: number) => {
+      let _reIndexed  = _mkVal;
+      _reIndexed.index = _index;
+      return _reIndexed;
+    });
+  }
+  return retVal;
+}
+
+export function sortMatchKeyTokensByIndex(value: SzMatchKeyTokenComposite[]): SzMatchKeyTokenComposite[] {
+  let retVal  = value;
+  if(retVal && retVal.sort) {
+    // first sort by any existing indexes
+    retVal = retVal.sort((a, b) => {    
+        if (a.index > b.index) {
+            return 1;
+        } else if (a.index < b.index) {    
+            return -1;
+        } else {
+          // sort by name
+        }
+        return 0;
+    });
+    // now update index values to same as array
+    retVal  = retVal.map((_mkVal: SzMatchKeyTokenComposite, _index: number) => {
       let _reIndexed  = _mkVal;
       _reIndexed.index = _index;
       return _reIndexed;

--- a/src/lib/graph/sz-graph-filter.component.html
+++ b/src/lib/graph/sz-graph-filter.component.html
@@ -141,7 +141,19 @@
   <div *ngIf="showMatchKeyTokens && showMatchKeyTokenFilters">
     <hr>
     <h3>{{ sectionTitles[5] }}</h3>
-    <form [formGroup]="filterByMatchKeyTokensForm">
+    <mat-chip-list 
+      #matchKeyChipList
+      class="match-keys mat-chip-list-stacked" 
+      aria-orientation="vertical" 
+      aria-label="Match Key Filters">
+      <mat-chip *ngFor="let mk of matchKeyTokens; let i = index"
+        [class.selected]="isMatchKeyTokenSelected(mk.name)"
+        (click)="onMkTagFilterToggle(mk.name)"
+        [matBadge]="mk.count" matBadgePosition="after" matBadgeColor="accent">
+        {{mk.name}}
+      </mat-chip>
+    </mat-chip-list>
+    <!--<form [formGroup]="filterByMatchKeyTokensForm">
     <ul class="filters-list">
       <ng-container *ngFor="let ds of filterByMatchKeyTokenData.controls; let i = index">
           <ng-container *ngIf="shouldMatchKeyTokenBeDisplayed(matchKeyTokens[i].name)">
@@ -153,6 +165,6 @@
           </ng-container>
       </ng-container>
     </ul>
-    </form>
+    </form>-->
   </div>
 </div>

--- a/src/lib/graph/sz-graph-filter.component.html
+++ b/src/lib/graph/sz-graph-filter.component.html
@@ -138,4 +138,21 @@
     </ul>
     </form>
   </div>
+  <div *ngIf="showMatchKeyTokens && showMatchKeyTokenFilters">
+    <hr>
+    <h3>{{ sectionTitles[5] }}</h3>
+    <form [formGroup]="filterByMatchKeyTokensForm">
+    <ul class="filters-list">
+      <ng-container *ngFor="let ds of filterByMatchKeyTokenData.controls; let i = index">
+          <ng-container *ngIf="shouldMatchKeyTokenBeDisplayed(matchKeyTokens[i].name)">
+              <li formArrayName="matchkeytokens">
+                <label>
+                  <input type="checkbox" [formControlName]="i" (change)="onMkTagFilterChange(matchKeyTokens[i].name, $event)">{{matchKeyTokens[i].name}}
+                </label>
+              </li>
+          </ng-container>
+      </ng-container>
+    </ul>
+    </form>
+  </div>
 </div>

--- a/src/lib/graph/sz-graph-filter.component.scss
+++ b/src/lib/graph/sz-graph-filter.component.scss
@@ -117,6 +117,25 @@
       width: 0px;
     }
   }
+
+  mat-chip-list.match-keys {
+    .mat-chip-list-wrapper {
+      display: inline-flex;
+    }
+    mat-chip {
+      font-size: 10px;
+      padding: 4px 12px;
+      margin-right: 20px;
+      display: inline-block;
+      width: unset;
+      min-height: 26px;
+      color: #525252;
+
+      &.selected {
+        background-color: rgb(208, 224, 228);
+      }
+    }
+  }
 }
 
 @-moz-document url-prefix() { 

--- a/src/lib/graph/sz-graph-filter.component.ts
+++ b/src/lib/graph/sz-graph-filter.component.ts
@@ -83,7 +83,7 @@ export class SzGraphFilterComponent implements OnInit, AfterViewInit, OnDestroy 
     return retVal;
   }
   @Input() public set showMatchKeyTokens(value: Array<SzMatchKeyTokenComposite>) {
-    console.log('showMatchKeyTokens.set()', value, Object.keys(this.filterByMatchKeyTokensForm.controls), (<FormArray>this.filterByMatchKeysForm.get('matchkeys')));
+    console.log('showMatchKeyTokens.set()', value);
     if(value && value.map && value !== undefined) {
       this._matchKeyTokens = value.map((matchKeyComposite: SzMatchKeyTokenComposite, ind: number) => {
         return Object.assign(matchKeyComposite, {
@@ -91,7 +91,7 @@ export class SzGraphFilterComponent implements OnInit, AfterViewInit, OnDestroy 
           'hidden': false
         });
       });
-      this.initializeMatchKeyTokenFormControls();
+      //this.initializeMatchKeyTokenFormControls();
     }
   }
   public get showMatchKeyTokens(): Array<SzMatchKeyTokenComposite> {
@@ -207,9 +207,10 @@ export class SzGraphFilterComponent implements OnInit, AfterViewInit, OnDestroy 
     return <FormArray>this.filterByMatchKeysForm.get('matchkeys');
   }
   /** get data from reactive form control array */
+  /*
   public get filterByMatchKeyTokenData() {
     return <FormArray>this.filterByMatchKeyTokensForm.get('matchkeytokens');
-  }
+  }*/
 
   // --------------------------------- event emmitters and subjects ----------------------
   /**
@@ -225,7 +226,7 @@ export class SzGraphFilterComponent implements OnInit, AfterViewInit, OnDestroy 
   /** the form group for the filters by datasource list */
   filterByDataSourcesForm: FormGroup;
   filterByMatchKeysForm: FormGroup;
-  filterByMatchKeyTokensForm: FormGroup;
+  //filterByMatchKeyTokensForm: FormGroup;
   /** the form group for colors by datasource list */
   colorsByDataSourcesForm: FormGroup;
   /** the form group for maxDegreesOfSeparation, maxEntities, buildOut parameter sliders */
@@ -256,9 +257,10 @@ export class SzGraphFilterComponent implements OnInit, AfterViewInit, OnDestroy 
       matchkeys: new FormArray([])
     });
     // filter by match keys tags
+    /*
     this.filterByMatchKeyTokensForm = this.formBuilder.group({
       matchkeytokens: new FormArray([])
-    });
+    });*/
     // colors by datasources
     this.colorsByDataSourcesForm = this.formBuilder.group({
       datasources: new FormArray([])
@@ -290,6 +292,7 @@ export class SzGraphFilterComponent implements OnInit, AfterViewInit, OnDestroy 
     //console.log('@senzing/sdk-components-ng/sz-entity-detail-graph-filter.onMkFilterChange',this.prefs.graph.matchKeysIncluded);
   }
   /** handler for when a filter by match key token value in the "filterByMatchKeyTokensForm" has changed */
+  /*
   onMkTagFilterChange(mkValue: string, evt?) {
     const includedMatchKeyTokenNames = this.filterByMatchKeyTokensForm.value.matchkeytokens
       .map((v, i) => v ? this.matchKeyTokens[i].name :  null)
@@ -297,6 +300,32 @@ export class SzGraphFilterComponent implements OnInit, AfterViewInit, OnDestroy 
     // update filters pref    
     this.prefs.graph.matchKeyTokensIncluded = includedMatchKeyTokenNames;
     console.log('@senzing/sdk-components-ng/sz-entity-detail-graph-filter.onMkTagFilterChange',this.prefs.graph.matchKeyTokensIncluded, includedMatchKeyTokenNames);
+  }*/
+  onMkTagFilterToggle( mkName: string ) {
+    let _matchKeyTokensIncludedMemCopy: string[] = [];
+    if(this.matchKeyTokensIncluded && this.matchKeyTokensIncluded.length) {
+      let _matchKeyTokensIncludedMemCopy = [].concat(this.matchKeyTokensIncluded);
+
+      let _existingKeyPos = _matchKeyTokensIncludedMemCopy.indexOf(mkName);
+      if(_existingKeyPos > -1 && _matchKeyTokensIncludedMemCopy[_existingKeyPos]) {
+        // remove from position
+        _matchKeyTokensIncludedMemCopy.splice(_existingKeyPos,1);
+        this.prefs.graph.matchKeyTokensIncluded = _matchKeyTokensIncludedMemCopy;
+        console.log(`@senzing/sdk-components-ng/sz-entity-detail-graph-filter.onMkTagFilterToggle: removed ${mkName} from cloud value`,_matchKeyTokensIncludedMemCopy);
+      } else {
+        // add to included token list
+        _matchKeyTokensIncludedMemCopy.push( mkName );
+        this.prefs.graph.matchKeyTokensIncluded = _matchKeyTokensIncludedMemCopy;
+        console.log(`@senzing/sdk-components-ng/sz-entity-detail-graph-filter.onMkTagFilterToggle: added ${mkName} to cloud value`,_matchKeyTokensIncludedMemCopy);
+      }
+    } else {
+      // add to included token list
+      _matchKeyTokensIncludedMemCopy.push( mkName );
+      this.prefs.graph.matchKeyTokensIncluded = _matchKeyTokensIncludedMemCopy;
+      console.log(`@senzing/sdk-components-ng/sz-entity-detail-graph-filter.onMkTagFilterToggle: added ${mkName} to cloud value`,_matchKeyTokensIncludedMemCopy);
+    }
+    //this.prefs.graph.matchKeyTokensIncluded = _matchKeyTokensIncludedMemCopy;
+    //console.log('@senzing/sdk-components-ng/sz-entity-detail-graph-filter.onMkTagFilterToggle',this.prefs.graph.matchKeyTokensIncluded, _matchKeyTokensIncludedMemCopy);
   }
   
   /**
@@ -513,12 +542,13 @@ export class SzGraphFilterComponent implements OnInit, AfterViewInit, OnDestroy 
     }
     //console.log('@senzing/sdk-components-ng/sz-entity-detail-graph-filter.removeAllMatchKeyControls: ', this.filterByMatchKeysData, this.matchKeysIncluded);
   }
+  /*
   private removeAllMatchKeyTokenControls() {
     while(this.filterByMatchKeyTokenData.length > 0){
       this.filterByMatchKeyTokenData.removeAt(this.filterByMatchKeyTokenData.length - 1);
     }
     //console.log('@senzing/sdk-components-ng/sz-entity-detail-graph-filter.removeAllMatchKeyControls: ', this.filterByMatchKeysData, this.matchKeysIncluded);
-  }
+  }*/
 
   private initializeMatchKeysFormControls() {
     //console.log('@senzing/sdk-components-ng/sz-entity-detail-graph-filter.initializeMatchKeysFormControls: ', this.matchKeys, this.showMatchKeys, this.matchKeysIncluded);
@@ -535,6 +565,7 @@ export class SzGraphFilterComponent implements OnInit, AfterViewInit, OnDestroy 
       });
     }
   }
+  /*
   private initializeMatchKeyTokenFormControls() {
     console.log('@senzing/sdk-components-ng/sz-entity-detail-graph-filter.initializeMatchKeysFormControls: ', this.matchKeyTokens, this.showMatchKeyTokens, this.matchKeyTokensIncluded);
     if(this.matchKeyTokens) {
@@ -549,7 +580,7 @@ export class SzGraphFilterComponent implements OnInit, AfterViewInit, OnDestroy 
         (this.filterByMatchKeyTokensForm.controls['matchkeytokens'] as FormArray).push(control1);
       });
     }
-  }
+  }*/
 
   /** helper method for retrieving list of datasources */
   public getDataSources() {
@@ -563,8 +594,19 @@ export class SzGraphFilterComponent implements OnInit, AfterViewInit, OnDestroy 
   public shouldMatchKeyBeDisplayed( mkName: string) {
     return (this.showMatchKeys && this.showMatchKeys.length > 0) ? (this.showMatchKeys.indexOf( mkName ) > -1) : true;
   }
+  public isMatchKeyTokenSelected( mkName: string ) {
+    let retVal = false;
+    if(this.matchKeyTokensIncluded && this.matchKeyTokensIncluded.length > 0) {
+      retVal = this.matchKeyTokensIncluded.indexOf(mkName) > -1 ? true : false;
+      //console.log(`#${mkName} in selected match keys? ${retVal}`, this.matchKeyTokensIncluded.indexOf(mkName), this.matchKeysIncluded);
+    } else {
+      //console.log(`#${mkName} not found in selected match keys: `, this.matchKeyTokensIncluded);
+    }
+    return retVal;
+  }
   /** if "showMatchKeys" array is specified, check that string name is present in list */
   public shouldMatchKeyTokenBeDisplayed( mkName: string) {
+    //console.log(`show "${mkName}" filter?`, this.showMatchKeyTokens);
     return true;
     return (this.showMatchKeyTokens && this.showMatchKeyTokens.length > 0) ? (this.showMatchKeyTokens.findIndex( (mkCat)=> { return mkCat.name === mkName; } ) > -1) : true;
   }

--- a/src/lib/graph/sz-graph-filter.component.ts
+++ b/src/lib/graph/sz-graph-filter.component.ts
@@ -280,7 +280,7 @@ export class SzGraphFilterComponent implements OnInit, AfterViewInit, OnDestroy 
     // update filters pref
     this.prefs.graph.dataSourcesFiltered = filteredDataSourceNames;
   }
-  /** handler for when a filter by datasouce value in the "filterByDataSourcesForm" has changed */
+  /** handler for when a filter by match key value in the "filterByMatchKeysForm" has changed */
   onMkFilterChange(mkValue: string, evt?) {
     const includedMatchKeyNames = this.filterByMatchKeysForm.value.matchkeys
       .map((v, i) => v ? this.matchKeys[i].name :  null)
@@ -289,7 +289,7 @@ export class SzGraphFilterComponent implements OnInit, AfterViewInit, OnDestroy 
     this.prefs.graph.matchKeysIncluded = includedMatchKeyNames;
     //console.log('@senzing/sdk-components-ng/sz-entity-detail-graph-filter.onMkFilterChange',this.prefs.graph.matchKeysIncluded);
   }
-  /** handler for when a filter by datasouce value in the "filterByDataSourcesForm" has changed */
+  /** handler for when a filter by match key token value in the "filterByMatchKeyTokensForm" has changed */
   onMkTagFilterChange(mkValue: string, evt?) {
     const includedMatchKeyTokenNames = this.filterByMatchKeyTokensForm.value.matchkeytokens
       .map((v, i) => v ? this.matchKeyTokens[i].name :  null)

--- a/src/lib/graph/sz-graph.component.html
+++ b/src/lib/graph/sz-graph.component.html
@@ -43,7 +43,9 @@
         (optionChanged)="onOptionChange($event)"
         [showDataSources]="filterShowDataSources"
         [showMatchKeys]="filterShowMatchKeys"
+        [showMatchKeyTokens]="filterShowMatchKeyTokens"
         [showMatchKeyFilters]="showMatchKeyFilters"
+        [showMatchKeyTokenFilters]="showMatchKeyTokenFilters"
       ></sz-graph-filter>
   
       <svg class="popout-icon"

--- a/src/lib/graph/sz-graph.component.html
+++ b/src/lib/graph/sz-graph.component.html
@@ -19,7 +19,7 @@
       [linkGravity]="5"
       [highlight]="entityNodeColors"
       [filter]="entityNodeFilters"
-      [includes]="entityMatchFilter"
+      [includes]="entityMatchTokenFilter"
       [showLinkLabels]="_showMatchKeys"
       (contextMenuClick)="onRightClick($event)"
       (entityClick)="onEntityClick($event)"

--- a/src/lib/graph/sz-graph.component.ts
+++ b/src/lib/graph/sz-graph.component.ts
@@ -117,6 +117,7 @@ export class SzGraphComponent implements OnInit, OnDestroy {
 
   @Input() dataSourcesFiltered: string[] = [];
   @Input() matchKeysIncluded: string[] = [];
+  @Input() matchKeyTokensIncluded: string[] = [];
   
   /** @internal */
   private _showPopOutIcon = false;
@@ -602,14 +603,15 @@ export class SzGraphComponent implements OnInit, OnDestroy {
       // should trigger full redraw
       queryParamChanged = true;
     }
-    this._showMatchKeys = prefs.showMatchKeys;
-    this.maxDegrees = prefs.maxDegreesOfSeparation;
-    this.maxEntities = prefs.maxEntities;
-    this.buildOut = prefs.buildOut;
-    this.dataSourceColors = prefs.dataSourceColors;
-    this.dataSourcesFiltered = prefs.dataSourcesFiltered;
-    this.matchKeysIncluded = prefs.matchKeysIncluded;
-    this.neverFilterQueriedEntityIds = prefs.neverFilterQueriedEntityIds;
+    this._showMatchKeys               = prefs.showMatchKeys;
+    this.maxDegrees                   = prefs.maxDegreesOfSeparation;
+    this.maxEntities                  = prefs.maxEntities;
+    this.buildOut                     = prefs.buildOut;
+    this.dataSourceColors             = prefs.dataSourceColors;
+    this.dataSourcesFiltered          = prefs.dataSourcesFiltered;
+    this.matchKeysIncluded            = prefs.matchKeysIncluded;
+    this.matchKeyTokensIncluded       = prefs.matchKeyTokensIncluded;
+    this.neverFilterQueriedEntityIds  = prefs.neverFilterQueriedEntityIds;
     if(prefs.queriedEntitiesColor && prefs.queriedEntitiesColor !== undefined && prefs.queriedEntitiesColor !== null) {
       this.queriedEntitiesColor = prefs.queriedEntitiesColor;
     }
@@ -690,6 +692,17 @@ export class SzGraphComponent implements OnInit, OnDestroy {
           selectorArgs: this.matchKeysIncluded
         };
       //});
+    }
+    return _ret;
+  }
+
+  public get entityMatchTokenFilter(): NodeFilterPair {
+    let _ret: NodeFilterPair;
+    if(this.matchKeyTokensIncluded && this.showMatchKeyTokenFilters) {
+      _ret = {
+        selectorFn: this.isMatchKeyTokenInEntityNode.bind(this, this.matchKeyTokensIncluded),
+        selectorArgs: this.matchKeyTokensIncluded
+      };
     }
     return _ret;
   }
@@ -776,6 +789,23 @@ export class SzGraphComponent implements OnInit, OnDestroy {
         retVal = (nodeData.relationshipMatchKeys.some( (mkName) => {
           return matchKeys.indexOf(mkName) > -1;
         }));
+      }
+    }
+    //console.log('isMatchKeyInEntityNode: ', matchKeys, nodeData, retVal);
+    return retVal;
+  }
+  private isMatchKeyTokenInEntityNode(matchKeyTokens?, nodeData?) {
+    let retVal = false;
+    if(this.neverFilterQueriedEntityIds && this.graphIds.indexOf( nodeData.entityId ) >= 0){
+      return true;
+    } else {
+      if(nodeData && nodeData.relationshipMatchKeyTokens && nodeData.relationshipMatchKeyTokens.indexOf){
+        // D3 filter query 
+        retVal = (nodeData.relationshipMatchKeyTokens.some( (tokenName) => {
+          return matchKeyTokens.indexOf(tokenName) > -1;
+        }));
+        //console.log(`isMatchKeyTokenInEntityNode: checking for "${matchKeyTokens}"? ${retVal}`, nodeData.relationshipMatchKeyTokens, );
+        //return true;
       }
     }
     //console.log('isMatchKeyInEntityNode: ', matchKeys, nodeData, retVal);

--- a/src/lib/models/graph.ts
+++ b/src/lib/models/graph.ts
@@ -9,6 +9,8 @@ export interface SzMatchKeyTokenComposite {
   disclosed: boolean,
   name: string
   count: number,
+  visible?: number,
+  entitiesOnCanvas?: Array<string|number>,
   entityIds: Array<string|number>,
   index?: number,
   hidden?: boolean

--- a/src/lib/models/graph.ts
+++ b/src/lib/models/graph.ts
@@ -3,3 +3,13 @@ export interface SzMatchKeyComposite {
     index?: number,
     hidden?: boolean
   }
+
+export interface SzMatchKeyTokenComposite {
+  derived: boolean,
+  disclosed: boolean,
+  name: string
+  count: number,
+  entityIds: Array<string|number>,
+  index?: number,
+  hidden?: boolean
+}

--- a/src/lib/sdk.material.module.ts
+++ b/src/lib/sdk.material.module.ts
@@ -17,12 +17,13 @@ import { MatSortModule } from '@angular/material/sort';
 import { MatPaginatorModule } from '@angular/material/paginator';
 import { MatSidenavModule } from '@angular/material/sidenav';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { MatChipsModule } from '@angular/material/chips'
 
 @NgModule({
   declarations: [],
-  imports: [ NoopAnimationsModule, DragDropModule, MatDialogModule, MatBadgeModule, MatBottomSheetModule, MatInputModule, MatTableModule, MatPaginatorModule, MatSortModule, MatSidenavModule, MatButtonModule, MatCheckboxModule, MatToolbarModule, MatTooltipModule, MatMenuModule, MatIconModule, MatGridListModule],
+  imports: [ NoopAnimationsModule, DragDropModule, MatDialogModule, MatBadgeModule, MatBottomSheetModule, MatChipsModule, MatInputModule, MatTableModule, MatPaginatorModule, MatSortModule, MatSidenavModule, MatButtonModule, MatCheckboxModule, MatToolbarModule, MatTooltipModule, MatMenuModule, MatIconModule, MatGridListModule],
   exports: [ 
-    DragDropModule, MatDialogModule, MatBadgeModule, MatBottomSheetModule, MatInputModule, MatTableModule, MatPaginatorModule, MatSortModule, MatSidenavModule, MatButtonModule, MatCheckboxModule, MatToolbarModule, MatTooltipModule, MatMenuModule, MatIconModule, MatGridListModule
+    DragDropModule, MatDialogModule, MatBadgeModule, MatBottomSheetModule, MatChipsModule, MatInputModule, MatTableModule, MatPaginatorModule, MatSortModule, MatSidenavModule, MatButtonModule, MatCheckboxModule, MatToolbarModule, MatTooltipModule, MatMenuModule, MatIconModule, MatGridListModule
   ],
 })
 export class SzSdkMaterialModule { }

--- a/src/lib/services/sz-prefs.service.ts
+++ b/src/lib/services/sz-prefs.service.ts
@@ -834,7 +834,8 @@ export class SzGraphPrefs extends SzSdkPrefsBase {
   ];
   /** @internal */
   private _matchKeysIncluded: string[] = [];
-
+  /** @internal */
+  private _matchKeyTokensIncluded: string[] = [];
   /** @internal */
   private _neverFilterQueriedEntityIds: boolean = true;
   /** @internal */
@@ -854,6 +855,7 @@ export class SzGraphPrefs extends SzSdkPrefsBase {
     'buildOut',
     'dataSourcesFiltered',
     'matchKeysIncluded',
+    'matchKeyTokensIncluded',
     'neverFilterQueriedEntityIds',
     'queriedEntitiesColor'
   ]
@@ -952,6 +954,15 @@ export class SzGraphPrefs extends SzSdkPrefsBase {
   /** hide any entity node when relationship does not contain a particular match key */
   public set matchKeysIncluded(value: string[]) {
     this._matchKeysIncluded = value;
+    if(!this.bulkSet && this._rememberStateOptions) this.prefsChanged.next( this.toJSONObject() );
+  }
+  /** hide any entity node when relationship does not contain a particular match key */
+  public get matchKeyTokensIncluded(): string[] {
+    return this._matchKeyTokensIncluded;
+  }
+  /** hide any entity node when relationship does not contain a particular match key */
+  public set matchKeyTokensIncluded(value: string[]) {
+    this._matchKeyTokensIncluded = value;
     if(!this.bulkSet && this._rememberStateOptions) this.prefsChanged.next( this.toJSONObject() );
   }
   /** never filter out the entities that were explicity declared in query */


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/13721038/162862583-9c7c3529-c480-4ffa-bc1a-6beb072b0f08.png)

# Pull request questions

## Which issue does this address

resolves #283 

## Why was change needed

To support *Filter By Match Key Tokens* functionality.

## What does change improve

The graph filters found in the `SzStandaloneGraphComponent` can now show a tag cloud of *Match Key Tokens*. If setting the `showMatchKeyTokenFilters="true"` you should also set the `showMatchKeyFilters]="false"` since the two options are exclusive and will interfere with proper function of the other.
