### PR TITLE
#286 match key tag filter css vars

### DIFF
--- a/src/lib/graph/sz-graph-filter.component.scss
+++ b/src/lib/graph/sz-graph-filter.component.scss
@@ -119,20 +119,30 @@
   }
 
   mat-chip-list.match-keys {
-    .mat-chip-list-wrapper {
-      display: inline-flex;
-    }
     mat-chip {
-      font-size: 10px;
-      padding: 4px 12px;
-      margin-right: 20px;
+      font-size: var(--sz-graph-filter-match-key-tags-font-size);
+      line-height: var(--sz-graph-filter-match-key-tags-line-height);
+      padding: var(--sz-graph-filter-match-key-tags-padding);
+      margin-right: var(--sz-graph-filter-match-key-tags-margin-right);
       display: inline-block;
-      width: unset;
-      min-height: 26px;
-      color: #525252;
+      width: var(--sz-graph-filter-match-key-tags-width);
+      min-height: var(--sz-graph-filter-match-key-tags-min-height);
+      color: var(--sz-graph-filter-match-key-tags-color);
+      background-color: var(--sz-graph-filter-match-key-tags-background-color);
+      cursor: var(--sz-graph-filter-match-key-tags-cursor);
+      user-select: none;
 
       &.selected {
-        background-color: rgb(208, 224, 228);
+        background-color: var(--sz-graph-filter-match-key-tags-selected-background-color); //rgb(208, 224, 228);
+        color: var(--sz-graph-filter-match-key-tags-selected-color); // inheirit
+        cursor: var(--sz-graph-filter-match-key-tags-selected-cursor);
+      }
+
+      .mat-badge-content {
+        background-color: var(--sz-graph-filter-match-key-tags-count-badge-background-color);
+        color: var(--sz-graph-filter-match-key-tags-count-badge-color);
+        top: var(--sz-graph-filter-match-key-tags-count-badge-top);
+        right: var(--sz-graph-filter-match-key-tags-count-badge-right);
       }
     }
   }

--- a/src/lib/scss/styles.scss
+++ b/src/lib/scss/styles.scss
@@ -75,6 +75,12 @@ body {
     }
 
   }
+  /* match key tag cloud for standalone graph and filter(s) */
+  mat-chip-list.match-keys .mat-chip-list-wrapper {
+    display: var(--sz-graph-filter-match-key-tags-display);
+    flex-direction: var(--sz-graph-filter-match-key-tags-flex-direction);
+    align-items: var(--sz-graph-filter-match-key-tags-align-items);
+  }
 
   .sz-graph-tooltip {
     position: absolute;

--- a/src/lib/scss/theme.scss
+++ b/src/lib/scss/theme.scss
@@ -350,6 +350,25 @@ body {
 
     /* graph filters */
     --sz-graph-filter-control-background-color: transparent;
+    --sz-graph-filter-match-key-tags-display: inline-flex;
+    --sz-graph-filter-match-key-tags-flex-direction: column;
+    --sz-graph-filter-match-key-tags-align-items: flex-start;
+    --sz-graph-filter-match-key-tags-font-size: 10px;
+    --sz-graph-filter-match-key-tags-line-height: inherit;
+    --sz-graph-filter-match-key-tags-padding: 4px 30px 4px 12px;
+    --sz-graph-filter-match-key-tags-margin-right: 20px;
+    --sz-graph-filter-match-key-tags-width: unset;
+    --sz-graph-filter-match-key-tags-min-height: 26px;
+    --sz-graph-filter-match-key-tags-color: #525252;
+    --sz-graph-filter-match-key-tags-background-color: #e0e0e0;
+    --sz-graph-filter-match-key-tags-cursor: pointer;
+    --sz-graph-filter-match-key-tags-selected-background-color: rgb(208, 224, 228);
+    --sz-graph-filter-match-key-tags-selected-color: inherit;
+    --sz-graph-filter-match-key-tags-selected-cursor: pointer;
+    --sz-graph-filter-match-key-tags-count-badge-top: 2px;
+    --sz-graph-filter-match-key-tags-count-badge-right: 3px;
+    --sz-graph-filter-match-key-tags-count-badge-background-color: #ffffffbd;
+    --sz-graph-filter-match-key-tags-count-badge-color: inheirit;
 
   /* end entity detail vars */
   /* start preferences component */


### PR DESCRIPTION
# Pull request questions

![image](https://user-images.githubusercontent.com/13721038/163095712-f278dc42-2c88-424d-a7d5-ddef7e6549af.png)

## Which issue does this address

resolves #286 

## Why was change needed

To be able to style the tag cloud externally through the use of css variables

## What does change improve

I added the following css variables width these defaults:

- `--sz-graph-filter-match-key-tags-display: inline-flex;`
- `--sz-graph-filter-match-key-tags-flex-direction: column;`
- `--sz-graph-filter-match-key-tags-align-items: flex-start;`
- `--sz-graph-filter-match-key-tags-font-size: 10px;`
- `--sz-graph-filter-match-key-tags-line-height: inherit;`
- `--sz-graph-filter-match-key-tags-padding: 4px 30px 4px 12px;`
- `--sz-graph-filter-match-key-tags-margin-right: 20px;`
- `--sz-graph-filter-match-key-tags-width: unset;`
- `--sz-graph-filter-match-key-tags-min-height: 26px;`
- `--sz-graph-filter-match-key-tags-color: #525252;`
- `--sz-graph-filter-match-key-tags-background-color: #e0e0e0;`
- `--sz-graph-filter-match-key-tags-cursor: pointer;`
- `--sz-graph-filter-match-key-tags-selected-background-color: rgb(208, 224, 228);`
- `--sz-graph-filter-match-key-tags-selected-color: inherit;`
- `--sz-graph-filter-match-key-tags-selected-cursor: pointer;`
- `--sz-graph-filter-match-key-tags-count-badge-top: 2px;`
- `--sz-graph-filter-match-key-tags-count-badge-right: 3px;`
- `--sz-graph-filter-match-key-tags-count-badge-background-color: #ffffffbd;`
- `--sz-graph-filter-match-key-tags-count-badge-color: inheirit;`

