### PR TITLE
#291 add option to limit scope of match key tokens to just primary rels

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -258,7 +258,6 @@
               "optimization": true,
               "outputHashing": "all",
               "sourceMap": false,
-              "extractCss": true,
               "namedChunks": false,
               "extractLicenses": true,
               "vendorChunk": false,
@@ -275,6 +274,49 @@
                   "maximumError": "10kb"
                 }
               ]
+            },
+            "debug": {
+              "fileReplacements": [
+                {
+                  "replace": "examples/search-in-graph/src/environments/environment.ts",
+                  "with": "examples/search-in-graph/src/environments/environment.prod.ts"
+                }
+              ],
+              "optimization": true,
+              "sourceMap": {
+                "scripts": true,
+                "styles": true,
+                "vendor": true
+              },
+              "namedChunks": false,
+              "extractLicenses": true,
+              "vendorChunk": false,
+              "buildOptimizer": true,
+              "budgets": [
+                {
+                  "type": "initial",
+                  "maximumWarning": "2mb",
+                  "maximumError": "5mb"
+                },
+                {
+                  "type": "anyComponentStyle",
+                  "maximumWarning": "6kb",
+                  "maximumError": "10kb"
+                }
+              ]
+            },
+            "development": {
+              "optimization": false,
+              "sourceMap": {
+                "scripts": true,
+                "styles": true,
+                "vendor": true
+              },
+              "namedChunks": true,
+              "extractLicenses": false,
+              "vendorChunk": true,
+              "buildOptimizer": false,
+              "budgets": []
             }
           }
         },
@@ -288,6 +330,12 @@
           "configurations": {
             "production": {
               "browserTarget": "@senzing/sdk-components-ng/examples/search-in-graph:build:production"
+            },
+            "debug": {
+              "browserTarget": "@senzing/sdk-components-ng/examples/search-in-graph:build:debug"
+            },
+            "development": {
+              "browserTarget": "@senzing/sdk-components-ng/examples/search-in-graph:build:development"
             }
           }
         },

--- a/examples/search-in-graph/src/app/app.component.html
+++ b/examples/search-in-graph/src/app/app.component.html
@@ -8,7 +8,7 @@
 <!-- start search box -->
 <div class="component-example">
   <sz-search
-    name="CHARLES SCERRI"
+    name="Jenny Smith"
     #searchBox
     disableIdentifierOptions="SSN_LAST4"
     enableIdentifierOptions="SOCIAL_NETWORK"
@@ -49,6 +49,8 @@
         [showMatchKeys]="true"
         [showMatchKeyFilters]="false"
         [showMatchKeyTokenFilters]="true"
+        [showCoreMatchKeyTokenChips]="true"
+        [showExtraneousMatchKeyTokenChips]="false"
         showZoomControl="true"
         (requestStarted)="onRequestStarted($event)"
         (renderComplete)="onRenderComplete($event)"

--- a/examples/search-with-results-and-details/src/app/app.component.html
+++ b/examples/search-with-results-and-details/src/app/app.component.html
@@ -62,6 +62,8 @@
     [showGraphMatchKeys]="true"
     [graphShowZoomControl]="true"
     graphZoomControlPosition="top-left"
+    [showRecordWhyUtilities]="true"
+    [showEntityWhyFunction]="true"
     [entityId]="currentlySelectedEntityId"></sz-entity-detail>
 </div>
 <!-- end entity detail -->

--- a/package-lock.json
+++ b/package-lock.json
@@ -4354,9 +4354,9 @@
       }
     },
     "@senzing/sdk-graph-components": {
-      "version": "4.1.0-beta.1",
-      "resolved": "https://registry.npmjs.org/@senzing/sdk-graph-components/-/sdk-graph-components-4.1.0-beta.1.tgz",
-      "integrity": "sha512-aBQhj4NIRMvepqw+/fMRntyAwmjFDzoPmIQELBsJuCfDTfnfD2mr8AsLcRFgspoED5E4fJr6Lp/0KGDELcROPA==",
+      "version": "4.1.0-beta.2",
+      "resolved": "https://registry.npmjs.org/@senzing/sdk-graph-components/-/sdk-graph-components-4.1.0-beta.2.tgz",
+      "integrity": "sha512-MFqQhHpyZgzZ8e0ay41tuPLsfqpC5v7oLrapp89UlZI0Jih90HowJMFnvH4AYVL35SmZEQMKdvN5BcH5efXdCA==",
       "requires": {
         "tslib": "^2.3.0"
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@senzing/sdk-components-ng",
-  "version": "4.0.0-beta.6",
+  "version": "4.0.0-beta.7",
   "scripts": {
     "ng": "ng",
     "start": "ng build @senzing/sdk-components-ng && ng serve",
@@ -38,14 +38,14 @@
     "example:aws-amplify-cognito": "ng serve @senzing/sdk-components-ng/examples/aws-amplify-cognito",
     "example:graph": "ng serve @senzing/sdk-components-ng/examples/graph",
     "example:search-by-id": "ng serve @senzing/sdk-components-ng/examples/search-by-id",
-    "example:search-in-graph": "ng serve @senzing/sdk-components-ng/examples/search-in-graph",
+    "example:search-in-graph": "ng serve @senzing/sdk-components-ng/examples/search-in-graph --configuration=development",
     "example:search-with-prefs": "ng serve @senzing/sdk-components-ng/examples/search-with-prefs",
     "example:search-with-results-and-details": "ng serve @senzing/sdk-components-ng/examples/search-with-results-and-details",
     "example:search-with-spinner": "ng serve @senzing/sdk-components-ng/examples/search-with-spinner",
     "example:with-why-features": "ng serve @senzing/sdk-components-ng/examples/with-why-features",
     "watch:search-with-prefs": "rm -fR dist/@senzing/sdk-components-ng && concurrently --kill-others \"wait-on file:dist/@senzing/sdk-components-ng/public-api.d.ts && ng serve example/search-with-prefs\" \"ng build @senzing/sdk-components-ng --watch\"",
     "watch:search-with-results-and-details": "rm -fR dist/@senzing/sdk-components-ng && concurrently --kill-others \"wait-on file:dist/@senzing/sdk-components-ng/public-api.d.ts && ng serve @senzing/sdk-components-ng/examples/search-with-results-and-details\" \"ng build @senzing/sdk-components-ng --watch\"",
-    "watch:search-in-graph": "rm -fR dist/@senzing/sdk-components-ng && concurrently --kill-others \"wait-on file:dist/@senzing/sdk-components-ng/public-api.d.ts && ng serve @senzing/sdk-components-ng/examples/search-in-graph\" \"ng build @senzing/sdk-components-ng --watch\"",
+    "watch:search-in-graph": "rm -fR dist/@senzing/sdk-components-ng && concurrently --kill-others \"wait-on file:dist/@senzing/sdk-components-ng/public-api.d.ts && ng serve @senzing/sdk-components-ng/examples/search-in-graph --configuration=debug\" \"ng build @senzing/sdk-components-ng --watch\"",
     "watch:search-by-id": "rm -fR dist/@senzing/sdk-components-ng && concurrently --kill-others \"wait-on file:dist/@senzing/sdk-components-ng/public-api.d.ts && ng serve @senzing/sdk-components-ng/examples/search-by-id\" \"ng build @senzing/sdk-components-ng --watch\"",
     "watch:with-why-features": "rm -fR dist/@senzing/sdk-components-ng && concurrently --kill-others \"wait-on file:dist/@senzing/sdk-components-ng/public-api.d.ts && ng serve @senzing/sdk-components-ng/examples/with-why-features\" \"ng build @senzing/sdk-components-ng --watch\""
   },
@@ -63,7 +63,7 @@
     "@angular/platform-browser-dynamic": "~13.2.0",
     "@angular/router": "~13.2.0",
     "@senzing/rest-api-client-ng": "^4.0.0",
-    "@senzing/sdk-graph-components": "^4.1.0-beta.1",
+    "@senzing/sdk-graph-components": "^4.1.0-beta.2",
     "acorn": "^8.6.0",
     "ajv": "^6.12.6",
     "d3": "^5.9.1",

--- a/src/lib/graph/sz-graph-filter.component.html
+++ b/src/lib/graph/sz-graph-filter.component.html
@@ -146,12 +146,24 @@
       class="match-keys mat-chip-list-stacked" 
       aria-orientation="vertical" 
       aria-label="Match Key Filters">
-      <mat-chip *ngFor="let mk of matchKeyTokens; let i = index"
-        [class.selected]="isMatchKeyTokenSelected(mk.name)"
-        (click)="onMkTagFilterToggle(mk.name)"
-        [matBadge]="mk.count" matBadgePosition="after" matBadgeColor="accent">
-        {{mk.name}}
-      </mat-chip>
+      
+      <div *ngIf="showCoreMatchKeyTokenChips" class="chip-group">
+        <mat-chip *ngFor="let mk of matchKeyCoreTokens; let i = index"
+          class="core-key"
+          [class.selected]="isMatchKeyCoreTokenSelected(mk.name)"
+          (click)="onCoreMkTagFilterToggle(mk.name)"
+          [matBadge]="mk.coreCount" matBadgePosition="after" matBadgeColor="accent">
+          {{mk.name}}
+        </mat-chip>
+      </div>
+      <div *ngIf="showExtraneousMatchKeyTokenChips" class="chip-group">
+        <mat-chip *ngFor="let mk of matchKeyTokens; let i = index"
+          [class.selected]="isMatchKeyTokenSelected(mk.name)"
+          (click)="onMkTagFilterToggle(mk.name)"
+          [matBadge]="mk.count" matBadgePosition="after" matBadgeColor="accent">
+          {{mk.name}}
+        </mat-chip>
+      </div>
     </mat-chip-list>
     <!--<form [formGroup]="filterByMatchKeyTokensForm">
     <ul class="filters-list">

--- a/src/lib/graph/sz-graph-filter.component.scss
+++ b/src/lib/graph/sz-graph-filter.component.scss
@@ -119,6 +119,7 @@
   }
 
   mat-chip-list.match-keys {
+
     mat-chip {
       font-size: var(--sz-graph-filter-match-key-tags-font-size);
       line-height: var(--sz-graph-filter-match-key-tags-line-height);
@@ -136,6 +137,9 @@
         background-color: var(--sz-graph-filter-match-key-tags-selected-background-color); //rgb(208, 224, 228);
         color: var(--sz-graph-filter-match-key-tags-selected-color); // inheirit
         cursor: var(--sz-graph-filter-match-key-tags-selected-cursor);
+        &.core-key {
+          background-color: rgb(238, 238, 164);
+        }
       }
 
       .mat-badge-content {

--- a/src/lib/graph/sz-graph.component.html
+++ b/src/lib/graph/sz-graph.component.html
@@ -46,6 +46,8 @@
         [showMatchKeyTokens]="filterShowMatchKeyTokens"
         [showMatchKeyFilters]="showMatchKeyFilters"
         [showMatchKeyTokenFilters]="showMatchKeyTokenFilters"
+        [showCoreMatchKeyTokenChips]="showCoreMatchKeyTokenChips"
+        [showExtraneousMatchKeyTokenChips]="showExtraneousMatchKeyTokenChips"
       ></sz-graph-filter>
   
       <svg class="popout-icon"

--- a/src/lib/models/graph.ts
+++ b/src/lib/models/graph.ts
@@ -1,3 +1,5 @@
+import { SzEntityIdentifier } from "@senzing/rest-api-client-ng"
+
 export interface SzMatchKeyComposite {
     name: string,
     index?: number,
@@ -9,9 +11,11 @@ export interface SzMatchKeyTokenComposite {
   disclosed: boolean,
   name: string
   count: number,
+  coreCount?: number,
   visible?: number,
   entitiesOnCanvas?: Array<string|number>,
   entityIds: Array<string|number>,
+  coreEntityIds?: Array<SzEntityIdentifier>,
   index?: number,
   hidden?: boolean
 }

--- a/src/lib/scss/styles.scss
+++ b/src/lib/scss/styles.scss
@@ -76,7 +76,8 @@ body {
 
   }
   /* match key tag cloud for standalone graph and filter(s) */
-  mat-chip-list.match-keys .mat-chip-list-wrapper {
+  mat-chip-list.match-keys .mat-chip-list-wrapper,
+  mat-chip-list.match-keys .chip-group {
     display: var(--sz-graph-filter-match-key-tags-display);
     flex-direction: var(--sz-graph-filter-match-key-tags-flex-direction);
     align-items: var(--sz-graph-filter-match-key-tags-align-items);

--- a/src/lib/scss/theme.scss
+++ b/src/lib/scss/theme.scss
@@ -369,6 +369,7 @@ body {
     --sz-graph-filter-match-key-tags-count-badge-right: 3px;
     --sz-graph-filter-match-key-tags-count-badge-background-color: #ffffffbd;
     --sz-graph-filter-match-key-tags-count-badge-color: inheirit;
+    --sz-graph-filter-match-key-core-tags-selected-background-color: rgb(238, 238, 164);
 
   /* end entity detail vars */
   /* start preferences component */

--- a/src/lib/services/sz-prefs.service.ts
+++ b/src/lib/services/sz-prefs.service.ts
@@ -837,6 +837,8 @@ export class SzGraphPrefs extends SzSdkPrefsBase {
   /** @internal */
   private _matchKeyTokensIncluded: string[] = [];
   /** @internal */
+  private _matchKeyCoreTokensIncluded: string[] = [];
+  /** @internal */
   private _neverFilterQueriedEntityIds: boolean = true;
   /** @internal */
   private _queriedEntitiesColor: string | undefined = "#465BA8";
@@ -856,6 +858,7 @@ export class SzGraphPrefs extends SzSdkPrefsBase {
     'dataSourcesFiltered',
     'matchKeysIncluded',
     'matchKeyTokensIncluded',
+    'matchKeyCoreTokensIncluded',
     'neverFilterQueriedEntityIds',
     'queriedEntitiesColor'
   ]
@@ -963,6 +966,15 @@ export class SzGraphPrefs extends SzSdkPrefsBase {
   /** hide any entity node when relationship does not contain a particular match key */
   public set matchKeyTokensIncluded(value: string[]) {
     this._matchKeyTokensIncluded = value;
+    if(!this.bulkSet && this._rememberStateOptions) this.prefsChanged.next( this.toJSONObject() );
+  }
+  /** hide any entity node when relationship does not contain a particular match key */
+  public get matchKeyCoreTokensIncluded(): string[] {
+    return this._matchKeyCoreTokensIncluded;
+  }
+  /** hide any entity node when relationship does not contain a particular match key */
+  public set matchKeyCoreTokensIncluded(value: string[]) {
+    this._matchKeyCoreTokensIncluded = value;
     if(!this.bulkSet && this._rememberStateOptions) this.prefsChanged.next( this.toJSONObject() );
   }
   /** never filter out the entities that were explicity declared in query */

--- a/src/package.json
+++ b/src/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@senzing/sdk-components-ng",
-  "version": "4.0.0-beta.6",
+  "version": "4.0.0-beta.7",
   "private": false,
   "keywords" :["Angular","Library","Senzing"],
   "license" : "SEE LICENSE IN LICENSE",

--- a/src/package.json
+++ b/src/package.json
@@ -24,6 +24,6 @@
     "@angular/core": "~13.2.0",
     "@angular/material": "~13.2.0",
     "@senzing/rest-api-client-ng": "^4.0.0",
-    "@senzing/sdk-graph-components": "^4.0.0"
+    "@senzing/sdk-graph-components": "^4.1.0"
   }
 }


### PR DESCRIPTION
# Pull request questions

## Which issue does this address

resolves #291 

## Why was change needed

There was an ask from @jbutcher21 for the Match Key Token filter(s) to only apply to the first-level deep relationships. He thought it was confusing that there match keys being show in the filter(s) list that were only present between entity nodes who'm themselves were related to the focal entity by a different match key(s).

## What does change improve

![image](https://user-images.githubusercontent.com/13721038/163898723-27398034-0e55-4744-9742-c63e5f7dcc23.png)

I'm not **100%** sure this is the _optimal_ solution, I _think_ what we probably **_should do_** is list the primary tags **_WITH_** the option to expand the list to include the other non-primary related tags for more capable filtering when needed(we definitely will need it when I merge in edge expansion). probably using a `...` and/or a different tag chip color etc but I need a little more time to work that out. This solution will get the job done for now.

- I added the following properties to `SzGraphFilterComponent`
- - `showCoreMatchKeyTokenChips`: default is false.
- - `showExtraneousMatchKeyTokenChips`: default is true.
- I added the following properties to `SzGraphComponent`
- - `showCoreMatchKeyTokenChips`: default is false.
- - `showExtraneousMatchKeyTokenChips`: default is true.
- I added `coreCount` and `coreEntityIds` to `SzMatchKeyComposite` interface model
- I added `matchKeyCoreTokens` getter to `SzGraphFilterComponent` to return just the `SzMatchKeyComposite` items that apply to core nodes.
- added `matchKeyCoreTokensIncluded` to `SzGraphPrefs` to differentiate between core match keys and extraneous(since they can overlap/diverge based on scope)

I also fixed the counts on the tag chips while I was in there.  ;-)
