### PR TITLE
#294 #295

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@senzing/sdk-components-ng",
-  "version": "4.0.0-beta.7",
+  "version": "4.0.0-beta.9",
   "scripts": {
     "ng": "ng",
     "start": "ng build @senzing/sdk-components-ng && ng serve",

--- a/src/lib/graph/sz-graph-filter.component.scss
+++ b/src/lib/graph/sz-graph-filter.component.scss
@@ -137,8 +137,9 @@
         background-color: var(--sz-graph-filter-match-key-tags-selected-background-color); //rgb(208, 224, 228);
         color: var(--sz-graph-filter-match-key-tags-selected-color); // inheirit
         cursor: var(--sz-graph-filter-match-key-tags-selected-cursor);
+
         &.core-key {
-          background-color: rgb(238, 238, 164);
+          background-color: var(--sz-graph-filter-match-key-core-tags-selected-background-color);
         }
       }
 

--- a/src/package.json
+++ b/src/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@senzing/sdk-components-ng",
-  "version": "4.0.0-beta.7",
+  "version": "4.0.0-beta.9",
   "private": false,
   "keywords" :["Angular","Library","Senzing"],
   "license" : "SEE LICENSE IN LICENSE",


### PR DESCRIPTION
# Pull request questions

## Which issue does this address

resolves #294 #295 

## Why was change needed

For entities with only a single record or <=1 why result we needed to pull additional info from a different node in the api response. Also, we weren't listing the "Why Result" row in the response.

## What does change improve

![image](https://user-images.githubusercontent.com/13721038/164315601-9b08a03a-3b97-4bc9-8e6f-3f5e58933758.png)
![image](https://user-images.githubusercontent.com/13721038/164316309-9b4fc476-ab5e-48e8-b93b-c3271a3b1225.png)

Entities why result component display: 

- spacing/margins
- scores now are dynamically pulled from response
- why result row added.
