### PR TITLE
#302 dblclick min/max why/whynot modal titlebar. 80vw restriction removed

### DIFF
--- a/src/lib/entity/detail/sz-entity-detail.component.ts
+++ b/src/lib/entity/detail/sz-entity-detail.component.ts
@@ -746,6 +746,8 @@ export class SzEntityDetailComponent implements OnInit, OnDestroy, AfterViewInit
     if(this._openWhyComparisonModalOnClick){
       this.dialog.open(SzWhyEntityDialog, {
         panelClass: 'why-entity-dialog-panel',
+        minHeight: 400,
+        minWidth: 800,
         data: {
           entityId: entityId
         }
@@ -759,6 +761,8 @@ export class SzEntityDetailComponent implements OnInit, OnDestroy, AfterViewInit
     if(this._openWhyComparisonModalOnClick) {
       this.dialog.open(SzWhyEntityDialog, {
         panelClass: 'why-entity-dialog-panel',
+        minHeight: 400,
+        minWidth: 800,
         data: {
           entityId: this.entity.resolvedEntity.entityId,
           showOkButton: false,
@@ -890,6 +894,8 @@ export class SzEntityDetailComponent implements OnInit, OnDestroy, AfterViewInit
       this.closeGraphContextMenu();
       this.dialog.open(SzWhyEntitiesDialog, {
         panelClass: 'why-entities-dialog-panel',
+        minHeight: 400,
+        minWidth: 800,
         data: {
           entities: [event.sourceEntityId, event.targetEntityId],
           showOkButton: false,

--- a/src/lib/scss/styles.scss
+++ b/src/lib/scss/styles.scss
@@ -50,10 +50,12 @@ body {
 .why-entity-dialog-panel, .why-entities-dialog-panel {
   max-width: 100vw !important;
   max-height: 100vh !important;
+  width: unset !important;
+  height: unset !important;
   .mat-dialog-container {
     padding: 0px;
-    height: 500px;  /* this is actually min-height because of the way material-dialogs work */
-    width: 900px;   /* this is actually min-width because of the way material-dialogs work */
+    //height: 500px;  /* this is actually min-height because of the way material-dialogs work */
+    //width: 900px;   /* this is actually min-width because of the way material-dialogs work */
     max-height: 100vh;
     overflow: hidden;
   }

--- a/src/lib/search/sz-search-results/sz-search-results.component.ts
+++ b/src/lib/search/sz-search-results/sz-search-results.component.ts
@@ -278,6 +278,8 @@ export class SzSearchResultsComponent implements OnInit, OnDestroy {
     if(this._openWhyComparisonModalOnClick) {
       this.dialog.open(SzWhyEntitiesDialog, {
         panelClass: 'why-entities-dialog-panel',
+        minWidth: '800px',
+        minHeight: '400px',
         data: {
           entities: selectedEntityIds,
           showOkButton: false,

--- a/src/lib/why/sz-why-entities-dialog.component.html
+++ b/src/lib/why/sz-why-entities-dialog.component.html
@@ -1,4 +1,4 @@
-<h1 mat-dialog-title cdkDrag cdkDragRootElement=".cdk-overlay-pane" cdkDragHandle>{{title}}</h1>
+<h1 mat-dialog-title cdkDrag cdkDragRootElement=".cdk-overlay-pane" (dblclick)="onDoubleClick($event)" cdkDragHandle>{{title}}</h1>
 <div mat-dialog-content>
   <sz-why-entities #whyEntitiesTag [entityIds]="entities" (loading)="onDataLoading($event)"></sz-why-entities>
   <!-- start spinner overlay -->

--- a/src/lib/why/sz-why-entities-dialog.component.scss
+++ b/src/lib/why/sz-why-entities-dialog.component.scss
@@ -3,6 +3,11 @@
     position: relative;
     height: 100%;
 
+    &.maximized {
+        width: 100vw;
+        height: 100vh;
+    }
+
     .mat-dialog-title {
         background-color: #6d738c;
         text-align: center;
@@ -100,4 +105,7 @@
     resize: both; 
     overflow: auto;
     background: #fff;
+}
+::ng-deep.why-entities-dialog-panel {
+    resize: both; 
 }

--- a/src/lib/why/sz-why-entity-dialog.component.html
+++ b/src/lib/why/sz-why-entity-dialog.component.html
@@ -1,4 +1,4 @@
-<h1 mat-dialog-title cdkDrag cdkDragRootElement=".cdk-overlay-pane" cdkDragHandle>{{title}}</h1>
+<h1 mat-dialog-title cdkDrag cdkDragRootElement=".cdk-overlay-pane" (dblclick)="onDoubleClick($event)" cdkDragHandle>{{title}}</h1>
 <div mat-dialog-content>
   <sz-why-entity #whyEntityTag [entityId]="entityId" [recordsToShow]="recordsToShow" (loading)="onDataLoading($event)"></sz-why-entity>
   <!-- start spinner overlay -->

--- a/src/lib/why/sz-why-entity-dialog.component.scss
+++ b/src/lib/why/sz-why-entity-dialog.component.scss
@@ -3,6 +3,11 @@
     position: relative;
     height: 100%;
 
+    &.maximized {
+        width: 100vw;
+        height: 100vh;
+    }
+
     .mat-dialog-title {
         background-color: #6d738c;
         text-align: center;

--- a/src/lib/why/sz-why-entity.component.ts
+++ b/src/lib/why/sz-why-entity.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, Input, Inject, OnDestroy, Output, EventEmitter, ViewChild } from '@angular/core';
+import { Component, OnInit, Input, Inject, OnDestroy, Output, EventEmitter, ViewChild, HostBinding } from '@angular/core';
 import { MatDialog, MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
 import { DataSource } from '@angular/cdk/collections';
 import { EntityDataService, SzAttributeSearchResult, SzEntityData, SzEntityFeature, SzEntityIdentifier, SzFeatureMode, SzFeatureScore, SzFocusRecordId, SzMatchedRecord, SzRecordId, SzWhyEntityResponse, SzWhyEntityResult } from '@senzing/rest-api-client-ng';
@@ -289,9 +289,13 @@ export class SzWhyEntityComponent implements OnInit, OnDestroy {
   styleUrls: ['sz-why-entity-dialog.component.scss']
 })
 export class SzWhyEntityDialog {
+  /** subscription to notify subscribers to unbind */
+  public unsubscribe$ = new Subject<void>();
+  
   private _entityId: SzEntityIdentifier;
   private _recordsToShow: SzRecordId[];
   private _showOkButton = true;
+  private _isMaximized = false;
   private _isLoading = true;
   public get isLoading(): boolean {
     return this._isLoading;
@@ -299,6 +303,9 @@ export class SzWhyEntityDialog {
   public get recordsToShow(): SzRecordId[] | undefined {
     return this._recordsToShow;
   }
+  @HostBinding('class.maximized') get maximized() { return this._isMaximized; }
+  private set maximized(value: boolean) { this._isMaximized = value; }
+
   @ViewChild('whyEntityTag') whyEntityTag: SzWhyEntityComponent;
 
   public get title(): string {
@@ -337,8 +344,20 @@ export class SzWhyEntityDialog {
       }
     }
   }
+  /**
+   * unsubscribe when component is destroyed
+   */
+   ngOnDestroy() {
+    this.unsubscribe$.next();
+    this.unsubscribe$.complete();
+  }
   public onDataLoading(isLoading: boolean) {
-    console.log('SzWhyEntityDialog.isLoading: ', isLoading);
     this._isLoading = isLoading;
+  }
+  public toggleMaximized() {
+    this.maximized = !this.maximized;
+  }
+  public onDoubleClick(event) {
+    this.toggleMaximized();
   }
 }


### PR DESCRIPTION
# Pull request questions

## Which issue does this address

resolves #302 

## Why was change needed

There was a **80% maximum** view width resize restriction set on the **_Why / Why Not_** modals. Some users reported that it was inconvenient. 

## What does change improve

- 80% width restriction removed
- Double click to toggle between 100vw/100vh and unset view width and height