### PR TITLE
#313 export missing models/interfaces

### DIFF
--- a/src/public-api.ts
+++ b/src/public-api.ts
@@ -66,9 +66,19 @@ export * from './lib/models/folio';
 export { SzBulkDataAnalysis } from './lib/models/data-analysis';
 export { SzBulkLoadStatus } from './lib/models/data-importing';
 export { SzEntitySearchParams } from './lib/models/entity-search';
+export { SzSearchResultEntityData } from './lib/models/responces/search-results/sz-search-result-entity-data';
 export { AdminStreamConnProperties, AdminStreamAnalysisConfig, AdminStreamLoadConfig, AdminStreamUploadRates } from './lib/models/data-admin';
 export { SzDataSourceRecordAnalysis, SzDataSourceComposite } from './lib/models/data-sources';
-export { SzGraphTooltipEntityModel, SzGraphTooltipLinkModel, SzGraphNodeFilterPair } from './lib/models/graph';
+export { 
+  SzGraphTooltipEntityModel, 
+  SzGraphTooltipLinkModel, 
+  SzGraphNodeFilterPair,
+  SzMatchKeyComposite,
+  SzMatchKeyTokenComposite,
+  SzEntityNetworkMatchKeyTokens,
+  SzNetworkGraphInputs
+} from './lib/models/graph';
+export { SzDataSourceRecordsSelection, SzDataSourceRecordSelection, SzWhySelectionModeBehavior, SzWhySelectionMode } from './lib/models/data-source-record-selection';
 
 /** why */
 export { SzWhyEntityComponent } from './lib/why/sz-why-entity.component';

--- a/src/public-api.ts
+++ b/src/public-api.ts
@@ -69,15 +69,7 @@ export { SzEntitySearchParams } from './lib/models/entity-search';
 export { SzSearchResultEntityData } from './lib/models/responces/search-results/sz-search-result-entity-data';
 export { AdminStreamConnProperties, AdminStreamAnalysisConfig, AdminStreamLoadConfig, AdminStreamUploadRates } from './lib/models/data-admin';
 export { SzDataSourceRecordAnalysis, SzDataSourceComposite } from './lib/models/data-sources';
-export { 
-  SzGraphTooltipEntityModel, 
-  SzGraphTooltipLinkModel, 
-  SzGraphNodeFilterPair,
-  SzMatchKeyComposite,
-  SzMatchKeyTokenComposite,
-  SzEntityNetworkMatchKeyTokens,
-  SzNetworkGraphInputs
-} from './lib/models/graph';
+export { SzGraphTooltipEntityModel, SzGraphTooltipLinkModel, SzGraphNodeFilterPair, SzMatchKeyComposite, SzMatchKeyTokenComposite, SzEntityNetworkMatchKeyTokens, SzNetworkGraphInputs } from './lib/models/graph';
 export { SzDataSourceRecordsSelection, SzDataSourceRecordSelection, SzWhySelectionModeBehavior, SzWhySelectionMode } from './lib/models/data-source-record-selection';
 
 /** why */


### PR DESCRIPTION
# Pull request questions

## Which issue does this address

resolves #313

## Why was change needed

Some models/objects **_WERE_** being exposed by `@senzing/sdk-graph-components` that now should be exposed by `@senzing/sdk-components-ng` since we relocated the graph components to this repository. Consuming applications that were referencing these models/objects would have no alternative/comparable type's to import otherwise. The following models are now exposed:
- [SzSearchResultEntityData](https://github.com/Senzing/sdk-components-ng/blob/main/src/lib/models/responces/search-results/sz-search-result-entity-data.ts) 
- [SzNetworkGraphInputs](https://github.com/Senzing/sdk-components-ng/blob/main/src/lib/models/graph.ts)
- [SzMatchKeyComposite](https://github.com/Senzing/sdk-components-ng/blob/main/src/lib/models/graph.ts)
- [SzMatchKeyTokenComposite](https://github.com/Senzing/sdk-components-ng/blob/main/src/lib/models/graph.ts)
- [SzGraphTooltipEntityModel](https://github.com/Senzing/sdk-components-ng/blob/main/src/lib/models/graph.ts)
- [SzGraphTooltipLinkModel](https://github.com/Senzing/sdk-components-ng/blob/main/src/lib/models/graph.ts)
- [SzGraphNodeFilterPair](https://github.com/Senzing/sdk-components-ng/blob/main/src/lib/models/graph.ts)
- [SzEntityNetworkMatchKeyTokens](https://github.com/Senzing/sdk-components-ng/blob/main/src/lib/models/graph.ts)

## What does change improve

compatibility
