### PR TITLE
Graph Filtering bugfixes and additions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,15 +6,68 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 [markdownlint](https://dlaa.me/markdownlint/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [5.0.1] - 2022-07-19
+## [5.1.0] - 2022-07-27
+
+- there is now a new `unlimited` ui option for maximum entities allowed.
+- there is now a new `unlimited` ui option for maximum build out allowed.
+- the upper limit of the maximum entities ui slider is now dynamically set from the initial query.
+- match key token counts now feature condensed notation instead of ellipsis
+
+
+### Added
+- the following event emitters added to `SzGraphFilterComponent`
+  - `matchKeyTokenSelectionScopeChanged` when the user switches from `CORE` to `EXTRANEOUS` match key token scope
+- the following getters and setters added to `SzGraphFilterComponent`
+  -  `maxEntitiesLimit` the maximum value that the slider control will allow. default is 200.
+  -  `unlimitedMaxEntities` ignore the `maxEntities` value and always pull up to 40000
+  -  `unlimitedMaxScope` ignore the `buildOut` value and always pull up to 10
+- the following getters and setters added to `SzGraphComponent`
+  - `unlimitedMaxEntities`
+  - `unlimitedMaxScope`
+  - `maxEntitiesFilterLimit`
+- the following event emitters on `SzGraphComponent`
+  - `renderStarted` not sure why this didn't exist since `renderComplete` did
+  - `dataLoading` for more flexible state sensing
+  - `onPreflightRequestComplete` so we can get the total relationship count to populate the `maxEntitiesFilterLimit`
+- the following properties/getters/setters added to `SzRelationshipNetworkComponent`
+  - `noMaxEntitiesLimit` sets whether or not to ignore the value set in `maxEntities`
+  - `noMaxScopeLimit` sets whether or not to ignore the value set in `buildOut`
+- the following event emitters added to `SzRelationshipNetworkComponent`
+  - `onTotalRelationshipsCountUpdated` is emitted with the value of how many total relationships are possible to display according to the data in the focal entities related entities.
+  - `renderStarted` wasn't wired correctly. works now
+  - `dataLoading` when a data request has been initiated.
+  - `dataLoaded` which is like `requestComplete` but instead of a boolean it returns the data response
+- the following preferences added to `SzGraphPrefs`
+  - `unlimitedMaxEntities`
+  - `unlimitedMaxScope`
+- `getEntitiesByIds` method added to `SzSearchService` to get data for multiple entities by their id's in the form of `Observable<SzEntityData[]>`
+
 
 ### Modified
 - Changed the behavior of `showCoreMatchKeyTokenChips` to automatically set `matchKeyTokenSelectionScope` to `CORE`.
 - Changed the complete match key display to a comma deliminated list of tokens on each line for readability
 - Changed the `shouldDataSourceBeDisplayed` method in `SzGraphFilterComponent` to allow for passing an empty array to `showDataSources` so we can initialize with an empty list that will prevent showing datasources before the list is ready.
 - Changed the `SzStandaloneGraphComponent` component to initialize the value of `showDataSources` in the filter component to NOT initially show data sources until the data can be properly rendered. (prevents FOC, see above)
+- the following getters and setters added to `SzGraphFilterComponent`
+  - `maxEntities` the maximum number of entities to display on the graph
+- the following changes made to `SzRelationshipNetworkComponent`
+  - `dataRequested` changed to BehaviorSubject (lifecycle bugfix)
+  - `requestStarted` fixed
+  - `requestComplete` fixed
+  - `getNetwork` signature changed to `getNetwork(entityIds: SzEntityIdentifier[], maxDegrees: number, buildOut: number, maxEntities: number)`
+  - the following event emitters have been rewired so that they are just proxies of 
+the observeable event streams for uniformity/reliability:
+    - `onRequestStarted`
+    - `onRequestCompleted`
+    - `onRenderStarted`
+    - `onRenderCompleted`
+    - `onNoResults`
+    - `onDataRequested`
+    - `onDataLoaded`
+    - `onDataUpdated`
+    - `scaleChanged`
 
-relevant tickets: #343 #344 #348
+relevant tickets: #343 #344 #347 #348 #350 #355
 
 ## [5.0.0] - 2022-07-01
 

--- a/examples/search-in-graph/src/app/app.component.html
+++ b/examples/search-in-graph/src/app/app.component.html
@@ -8,7 +8,6 @@
 <!-- start search box -->
 <div class="component-example">
   <sz-search
-    name="Jenny Smith"
     #searchBox
     disableIdentifierOptions="SSN_LAST4"
     enableIdentifierOptions="SOCIAL_NETWORK"
@@ -34,6 +33,7 @@
 
 <button (click)="onTabClick('detail')">show detail</button>
 <button (click)="onTabClick('filters')">show filters</button>
+<button (click)="toggleShowSpinner()">toggle showSpinner({{showSpinner}})</button>
 <div class="content-container">
   <!-- start graph control -->
   <div #graphContainer>
@@ -51,14 +51,29 @@
         [showMatchKeys]="true"
         [showMatchKeyFilters]="false"
         [showMatchKeyTokenFilters]="true"
-        [showCoreMatchKeyTokenChips]="false"
-        [showExtraneousMatchKeyTokenChips]="true"
+        [showCoreMatchKeyTokenChips]="true"
+        [showExtraneousMatchKeyTokenChips]="false"
+        [unlimitedMaxEntities]="true"
         showZoomControl="true"
         (requestStarted)="onRequestStarted($event)"
-        (renderComplete)="onRenderComplete($event)"
         (requestComplete)="onRequestComplete($event)"
+        (renderStarted)="onRenderStarted($event)"
+        (renderComplete)="onRenderComplete($event)"
+        (dataLoading)="onRequestStarted($event)"
+        (dataLoaded)="onDataLoaded($event)"
     ></sz-standalone-graph>
   </div>
+  <!-- start spinner overlay -->
+  <div class="mat-background" *ngIf="showSpinner">
+    <div class="spinner">
+        <div class="rect1"></div>
+        <div class="rect2"></div>
+        <div class="rect3"></div>
+        <div class="rect4"></div>
+        <div class="rect5"></div>
+    </div>
+  </div>
+  <!-- end spinner overlay -->
   <!--  end graph control  -->
 
   <!-- start entity detail -->

--- a/examples/search-in-graph/src/app/app.component.html
+++ b/examples/search-in-graph/src/app/app.component.html
@@ -53,7 +53,6 @@
         [showMatchKeyTokenFilters]="true"
         [showCoreMatchKeyTokenChips]="true"
         [showExtraneousMatchKeyTokenChips]="false"
-        [unlimitedMaxEntities]="true"
         showZoomControl="true"
         (requestStarted)="onRequestStarted($event)"
         (requestComplete)="onRequestComplete($event)"

--- a/examples/search-in-graph/src/app/app.component.scss
+++ b/examples/search-in-graph/src/app/app.component.scss
@@ -37,4 +37,54 @@
 
 
   }
+
+  .mat-background {
+    background-color: rgba($color: #000000, $alpha: 0.20);
+    position: fixed;
+    width: 100vw;
+    height: 100vh;
+    margin: 0px;
+    padding: 0px;
+    left: 0;
+    top: 0;
+}
+
+.spinner {
+    margin: 50vh auto;
+    text-align: center;
+    font-size: 10px;
+    width: 60px;
+    height: 60px;
+
+    div {
+        background-color: #333;
+        height: 100%;
+        width: 9px;
+        display: inline-block;
+        margin: 0 3px 0 0;
+
+        -webkit-animation: sk-stretchdelay 1.2s infinite ease-in-out;
+        animation: sk-stretchdelay 1.2s infinite ease-in-out;
+    }
+
+    .rect2 {
+    -webkit-animation-delay: -1.1s;
+    animation-delay: -1.1s;
+    }
+
+    .rect3 {
+    -webkit-animation-delay: -1.0s;
+    animation-delay: -1.0s;
+    }
+
+    .rect4 {
+    -webkit-animation-delay: -0.9s;
+    animation-delay: -0.9s;
+    }
+
+    .rect5 {
+    -webkit-animation-delay: -0.8s;
+    animation-delay: -0.8s;
+    }
+  }
 }

--- a/examples/search-in-graph/src/app/app.component.ts
+++ b/examples/search-in-graph/src/app/app.component.ts
@@ -29,9 +29,11 @@ export class AppComponent implements AfterViewInit {
   public unsubscribe$ = new Subject<void>();
   public currentSearchResults: SzAttributeSearchResult[];
   public currentlySelectedEntityId: number;
-  public searchResultEntityIds: SzEntityIdentifier[] = [40002];
+  //public searchResultEntityIds: SzEntityIdentifier[] = [40002];
+  //public searchResultEntityIds: SzEntityIdentifier[] = [39001,40002,40003,40005];
+  public searchResultEntityIds: SzEntityIdentifier[] = [40001,40003,40005,41001,44271];
   public currentSearchParameters: SzEntitySearchParams;
-  public showSearchResults = false;
+  public showSearchResults = true;
   public showSpinner = false;
   public _showMatchKeysInFilter: string[];
   
@@ -111,6 +113,10 @@ export class AppComponent implements AfterViewInit {
     });
   }
 
+  toggleShowSpinner() {
+    this.showSpinner = !this.showSpinner;
+  }
+
   onSearchException(err: Error) {
     throw (err.message);
   }
@@ -122,8 +128,20 @@ export class AppComponent implements AfterViewInit {
   onRequestComplete(evt: any) {
     console.log('onRequestComplete: ', evt);
   }
+  onRenderStarted(evt: any) {
+    console.log('onRenderStarted: ', evt);
+    this.showSpinner = true;
+  }
   onRenderComplete(evt: any) {
     console.log('onRenderComplete: ', evt);
+    this.showSpinner = false;
+  }
+  onDataLoading(evt: any) {
+    console.log('onDataLoading: ', evt);
+    this.showSpinner = true;
+  }
+  onDataLoaded(evt: any) {
+    console.log('onDataLoaded: ', evt);
     this.showSpinner = false;
   }
   onMatchKeysChange(data: string[]) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@senzing/sdk-components-ng",
-  "version": "5.0.0",
+  "version": "5.1.0",
   "scripts": {
     "ng": "ng",
     "start": "ng build @senzing/sdk-components-ng && ng serve",

--- a/src/lib/entity/detail/sz-entity-detail-graph/sz-entity-detail-graph.component.ts
+++ b/src/lib/entity/detail/sz-entity-detail-graph/sz-entity-detail-graph.component.ts
@@ -3,9 +3,8 @@ import {
   SzRelatedEntity,
   SzResolvedEntity
 } from '@senzing/rest-api-client-ng';
-import { SzGraphNodeFilterPair } from '../../../models/graph';
+import { SzGraphNodeFilterPair, SzNetworkGraphInputs } from '../../../models/graph';
 import { SzPrefsService } from '../../../services/sz-prefs.service';
-import { SzNetworkGraphInputs } from '../../../models/graph';
 import { SzGraphComponent } from '../../../graph/sz-graph.component';
 
 /**

--- a/src/lib/entity/detail/sz-entity-detail-graph/sz-standalone-graph.component.html
+++ b/src/lib/entity/detail/sz-entity-detail-graph/sz-standalone-graph.component.html
@@ -41,9 +41,12 @@
       (relationshipClick)="onLinkClick($event)"
       (relationshipContextMenuClick)="onLinkRightClick($event)"
       (noResults)="onNoResults($event)"
+      (onTotalRelationshipsCountUpdated)="onTotalRelationshipsCountUpdated($event)"
       (onDataLoaded)="onGraphDataLoaded($event)"
       (onDataUpdated)="onGraphDataUpdated($event)"
       (scaleChanged)="onGraphZoom($event)"
+      [noMaxEntitiesLimit]="unlimitedMaxEntities"
+      [noMaxScopeLimit]="unlimitedMaxScope"
       [maxEntities]="maxEntities"></sz-relationship-network>
   
     <sz-graph-control *ngIf="showMatchKeyControl" class="sz-graph-control"
@@ -69,7 +72,9 @@
         [showMatchKeyTokenSelectAll]="showMatchKeyTokenSelectAll"
         [showCoreMatchKeyTokenChips]="showCoreMatchKeyTokenChips"
         [showExtraneousMatchKeyTokenChips]="showExtraneousMatchKeyTokenChips"
+        [maxEntitiesLimit]="maxEntitiesFilterLimit"
     ></sz-graph-filter>
+    _maxEntitiesFilterLimit {{maxEntitiesFilterLimit}}
   
     <svg class="popout-icon"
         [class.top-left]="popOutIconPosition == 'top-left'"

--- a/src/lib/entity/detail/sz-entity-detail-graph/sz-standalone-graph.component.html
+++ b/src/lib/entity/detail/sz-entity-detail-graph/sz-standalone-graph.component.html
@@ -59,6 +59,7 @@
         [class.bottom-left]="filterControlPosition == 'bottom-left'"
         [showLinkLabels]="_showMatchKeys"
         (optionChanged)="onOptionChange($event)"
+        (matchKeyTokenSelectionScopeChanged)="onFilterMatchKeyTokenSelectionScopeChanged($event)"
         [showDataSources]="filterShowDataSources"
         [showMatchKeys]="filterShowMatchKeys"
         [showMatchKeyTokens]="filterShowMatchKeyTokens"

--- a/src/lib/entity/detail/sz-entity-detail-graph/sz-standalone-graph.component.html
+++ b/src/lib/entity/detail/sz-entity-detail-graph/sz-standalone-graph.component.html
@@ -74,7 +74,6 @@
         [showExtraneousMatchKeyTokenChips]="showExtraneousMatchKeyTokenChips"
         [maxEntitiesLimit]="maxEntitiesFilterLimit"
     ></sz-graph-filter>
-    _maxEntitiesFilterLimit {{maxEntitiesFilterLimit}}
   
     <svg class="popout-icon"
         [class.top-left]="popOutIconPosition == 'top-left'"

--- a/src/lib/entity/detail/sz-entity-detail-graph/sz-standalone-graph.component.ts
+++ b/src/lib/entity/detail/sz-entity-detail-graph/sz-standalone-graph.component.ts
@@ -7,6 +7,7 @@ import { SzEntityIdentifier } from '@senzing/rest-api-client-ng';
 import { SzWhyEntitiesDialog } from '../../../why/sz-why-entities.component';
 import { Overlay, OverlayRef } from '@angular/cdk/overlay';
 import { MatDialog } from '@angular/material/dialog';
+import { SzMatchKeyTokenFilterScope } from '../../../models/graph';
 
 /**
  * Embeddable Graph Component
@@ -188,6 +189,12 @@ export class SzStandaloneGraphComponent extends SzGraphComponent implements Afte
     if(this._showGraphLinkContextMenu) {
       this.openGraphContextMenu(event, this.graphLinkContextMenu);
     }
+  }
+  public onFilterMatchKeyTokenSelectionScopeChanged(scope: SzMatchKeyTokenFilterScope) {
+    console.log('sz-standalone-graph.onMatchKeyTokenSelectionScopeChanged: ', scope, this.matchKeyTokenSelectionScope === SzMatchKeyTokenFilterScope.CORE, this.matchKeyTokenSelectionScope === SzMatchKeyTokenFilterScope.EXTRANEOUS);
+    this.matchKeyTokenSelectionScope = scope;
+    this._showExtraneousMatchKeyTokenChips  = (this.matchKeyTokenSelectionScope === SzMatchKeyTokenFilterScope.EXTRANEOUS) ?  true : false;
+    this._showCoreMatchKeyTokenChips        = (this.matchKeyTokenSelectionScope === SzMatchKeyTokenFilterScope.CORE) ?        true : false;
   }
 
   /** can a specific entity node be removed from canvas */

--- a/src/lib/entity/detail/sz-entity-detail-graph/sz-standalone-graph.component.ts
+++ b/src/lib/entity/detail/sz-entity-detail-graph/sz-standalone-graph.component.ts
@@ -192,9 +192,10 @@ export class SzStandaloneGraphComponent extends SzGraphComponent implements Afte
   }
   public onFilterMatchKeyTokenSelectionScopeChanged(scope: SzMatchKeyTokenFilterScope) {
     console.log('sz-standalone-graph.onMatchKeyTokenSelectionScopeChanged: ', scope, this.matchKeyTokenSelectionScope === SzMatchKeyTokenFilterScope.CORE, this.matchKeyTokenSelectionScope === SzMatchKeyTokenFilterScope.EXTRANEOUS);
-    this.matchKeyTokenSelectionScope = scope;
+    this.matchKeyTokenSelectionScope        = scope;
     this._showExtraneousMatchKeyTokenChips  = (this.matchKeyTokenSelectionScope === SzMatchKeyTokenFilterScope.EXTRANEOUS) ?  true : false;
     this._showCoreMatchKeyTokenChips        = (this.matchKeyTokenSelectionScope === SzMatchKeyTokenFilterScope.CORE) ?        true : false;
+
   }
 
   /** can a specific entity node be removed from canvas */

--- a/src/lib/entity/detail/sz-entity-detail-graph/sz-standalone-graph.component.ts
+++ b/src/lib/entity/detail/sz-entity-detail-graph/sz-standalone-graph.component.ts
@@ -190,8 +190,9 @@ export class SzStandaloneGraphComponent extends SzGraphComponent implements Afte
       this.openGraphContextMenu(event, this.graphLinkContextMenu);
     }
   }
+  /** when the filter component's match key scope is changed from EXTRANEOUS to CORE or vice-versa */
   public onFilterMatchKeyTokenSelectionScopeChanged(scope: SzMatchKeyTokenFilterScope) {
-    console.log('sz-standalone-graph.onMatchKeyTokenSelectionScopeChanged: ', scope, this.matchKeyTokenSelectionScope === SzMatchKeyTokenFilterScope.CORE, this.matchKeyTokenSelectionScope === SzMatchKeyTokenFilterScope.EXTRANEOUS);
+    //console.log('sz-standalone-graph.onMatchKeyTokenSelectionScopeChanged: ', scope, this.matchKeyTokenSelectionScope === SzMatchKeyTokenFilterScope.CORE, this.matchKeyTokenSelectionScope === SzMatchKeyTokenFilterScope.EXTRANEOUS);
     this.matchKeyTokenSelectionScope        = scope;
     this._showExtraneousMatchKeyTokenChips  = (this.matchKeyTokenSelectionScope === SzMatchKeyTokenFilterScope.EXTRANEOUS) ?  true : false;
     this._showCoreMatchKeyTokenChips        = (this.matchKeyTokenSelectionScope === SzMatchKeyTokenFilterScope.CORE) ?        true : false;

--- a/src/lib/graph/sz-graph-filter.component.html
+++ b/src/lib/graph/sz-graph-filter.component.html
@@ -184,7 +184,7 @@
           class="core-key"
           [class.selected]="isMatchKeyCoreTokenSelected(mk.name)"
           (click)="onCoreMkTagFilterToggle(mk.name)"
-          [matBadge]="mk.coreCount" matBadgePosition="after" matBadgeColor="accent">
+          [matBadge]="getMKBadgeCount(mk.coreCount)" matBadgePosition="after" matBadgeColor="accent">
           {{mk.name}}
         </mat-chip>
       </div>
@@ -193,7 +193,7 @@
           class="extra-key"
           [class.selected]="isMatchKeyTokenSelected(mk.name)"
           (click)="onMkTagFilterToggle(mk.name)"
-          [matBadge]="mk.count" matBadgePosition="after" matBadgeColor="accent">
+          [matBadge]="getMKBadgeCount(mk.count)" matBadgePosition="after" matBadgeColor="accent">
           {{mk.name}}
         </mat-chip>
       </div>

--- a/src/lib/graph/sz-graph-filter.component.html
+++ b/src/lib/graph/sz-graph-filter.component.html
@@ -17,29 +17,48 @@
     </li>
 
     <li>
-      <label>
-        <div>
+      <label style="display: block;">
+        <div style="display: flex; flex-direction: row; justify-content: space-between;">
           <span class="has-tooltip">
             Scope
             <span class="tooltip tooptip-left">number of relationship hops away from focused entity</span>
           </span>
+          <span class="left-adjusted"><mat-checkbox [checked]="unlimitedMaxScope" (change)="onMaxUnlimitedChange('unlimitedMaxScope',$event.checked)">unlimited</mat-checkbox></span>
         </div>
-        <input type="range" [min]="buildOutMin" [max]="buildOutMax" formControlName="buildOut" [value]="buildOut" 
-          (change)="onIntParameterChange('buildOut', getValueFromEventTarget($event))" required>
+      </label>
+      <label *ngIf="!unlimitedMaxScope" style="display: flex; flex-direction: row; justify-content: space-between; align-content: center; flex-wrap: nowrap; align-items: center;">
+        <mat-slider style="width: 100%" min="1" [max]="buildOutMax" 
+        [disabled]="unlimitedMaxScope" 
+        [value]="buildOut"
+        (change)="onIntParameterChange('buildOut', $event.value)"
+        ></mat-slider>
+        <!--<input type="range" [min]="buildOutMin" [max]="buildOutMax" formControlName="buildOut" [value]="buildOut" 
+          (change)="onIntParameterChange('buildOut', getValueFromEventTarget($event))" required>-->
         <span class="intVal">({{ buildOut }})</span>
       </label>
     </li>
     <li *ngIf="showMaxEntities">
-      <label>
-        <div>
+      <label style="display: block;">
+        <div style="display: flex; flex-direction: row; justify-content: space-between;">
           <span class="has-tooltip">
             Max
             <span class="tooltip tooptip-left">hard limit on how many entities will be displayed</span>
           </span>
+          <span class="left-adjusted"><mat-checkbox [checked]="unlimitedMaxEntities" (change)="onMaxUnlimitedChange('unlimitedMaxEntities',$event.checked)">unlimited</mat-checkbox></span>
         </div>
-        <input type="range" min="1" max="99" step="3" [value]="maxEntities" formControlName="maxEntities" 
-          (change)="onIntParameterChange('maxEntities', getValueFromEventTarget($event))" required>
-        <span class="intVal">({{ maxEntities }})</span>
+      </label>
+      <label *ngIf="!unlimitedMaxEntities" style="display: flex; flex-direction: row; justify-content: space-between; align-content: center; flex-wrap: nowrap; align-items: center;">
+        <mat-slider style="width: 100%" min="1" [max]="maxEntitiesLimit + 3" step="3" 
+        [disabled]="unlimitedMaxEntities" 
+        [value]="maxEntities"
+        (change)="onIntParameterChange('maxEntities', $event.value)"
+        ></mat-slider>
+        <!--<input type="range" 
+          min="1" [max]="maxEntitiesLimit + 3" 
+          [disabled]="true"
+          [value]="maxEntities" formControlName="maxEntities" 
+          (change)="onIntParameterChange('maxEntities', getValueFromEventTarget($event))" required>-->        
+        <span>({{ maxEntitiesValueLabel }}) of {{ maxEntitiesLimit }}</span>
       </label>
     </li>
     <li *ngIf="showMaxDegreesOfSeparation">
@@ -142,9 +161,9 @@
   </div>
   <div *ngIf="showMatchKeyTokens && showMatchKeyTokenFilters">
     <hr>
-    <div class="filter-header">
+    <div class="filter-header match-key-token-filter-header">
       <h3>
-        {{ sectionTitles[5] }} | {{ matchKeyTokenSelectionScope }}
+        {{ sectionTitles[5] }}
       </h3>
       <div *ngIf="showMatchKeyTokenSelectAll" class="bulk-select-options">
         [<span (click)="onSelectAllMatchKeyTokens(true)">All On</span> | <span (click)="onSelectAllMatchKeyTokens(false)">All Off</span>]

--- a/src/lib/graph/sz-graph-filter.component.html
+++ b/src/lib/graph/sz-graph-filter.component.html
@@ -58,7 +58,7 @@
           [disabled]="true"
           [value]="maxEntities" formControlName="maxEntities" 
           (change)="onIntParameterChange('maxEntities', getValueFromEventTarget($event))" required>-->        
-        <span>({{ maxEntitiesValueLabel }}) of {{ maxEntitiesLimit }}</span>
+        <span style="white-space: nowrap;">({{ maxEntitiesValueLabel }}) of {{ maxEntitiesLimit }}</span>
       </label>
     </li>
     <li *ngIf="showMaxDegreesOfSeparation">

--- a/src/lib/graph/sz-graph-filter.component.html
+++ b/src/lib/graph/sz-graph-filter.component.html
@@ -123,7 +123,9 @@
   </form>
   <div *ngIf="showMatchKeys && showMatchKeyFilters">
     <hr>
-    <h3>{{ sectionTitles[4] }}</h3>
+    <h3>
+      {{ sectionTitles[4] }}
+    </h3>
     <form [formGroup]="filterByMatchKeysForm">
     <ul class="filters-list">
       <ng-container *ngFor="let ds of filterByMatchKeysData.controls; let i = index">
@@ -141,18 +143,24 @@
   <div *ngIf="showMatchKeyTokens && showMatchKeyTokenFilters">
     <hr>
     <div class="filter-header">
-      <h3>{{ sectionTitles[5] }}</h3>
+      <h3>
+        {{ sectionTitles[5] }} | {{ matchKeyTokenSelectionScope }}
+      </h3>
       <div *ngIf="showMatchKeyTokenSelectAll" class="bulk-select-options">
         [<span (click)="onSelectAllMatchKeyTokens(true)">All On</span> | <span (click)="onSelectAllMatchKeyTokens(false)">All Off</span>]
       </div>
     </div>
+    <mat-slide-toggle 
+      class="match-key-token-mode-select" 
+      [checked]="isMatchKeyTokenSelectionScopeCore"
+      (change)="onMatchKeyCoreModeToggle($event.checked)">Primary Only</mat-slide-toggle>
     <mat-chip-list 
       #matchKeyChipList
       class="match-keys mat-chip-list-stacked" 
       aria-orientation="vertical" 
       aria-label="Match Key Filters">
       
-      <div *ngIf="showCoreMatchKeyTokenChips" class="chip-group">
+      <div *ngIf="showCoreMatchKeyTokenChips" class="chip-group core">
         <mat-chip *ngFor="let mk of matchKeyCoreTokens; let i = index"
           class="core-key"
           [class.selected]="isMatchKeyCoreTokenSelected(mk.name)"
@@ -161,8 +169,9 @@
           {{mk.name}}
         </mat-chip>
       </div>
-      <div *ngIf="showExtraneousMatchKeyTokenChips" class="chip-group">
+      <div *ngIf="showExtraneousMatchKeyTokenChips" class="chip-group extraneous">
         <mat-chip *ngFor="let mk of matchKeyTokens; let i = index"
+          class="extra-key"
           [class.selected]="isMatchKeyTokenSelected(mk.name)"
           (click)="onMkTagFilterToggle(mk.name)"
           [matBadge]="mk.count" matBadgePosition="after" matBadgeColor="accent">

--- a/src/lib/graph/sz-graph-filter.component.scss
+++ b/src/lib/graph/sz-graph-filter.component.scss
@@ -138,7 +138,7 @@
       width: 0px;
     }
   }
-
+  /*
   .chip-group {
     &.core {
       border: 1px solid salmon;
@@ -146,7 +146,7 @@
     &.extraneous {
       border: 1px solid lightblue;
     }
-  }
+  }*/
 
   .match-key-token-mode-select {
     display: block;
@@ -183,6 +183,9 @@
         color: var(--sz-graph-filter-match-key-tags-count-badge-color);
         top: var(--sz-graph-filter-match-key-tags-count-badge-top);
         right: var(--sz-graph-filter-match-key-tags-count-badge-right);
+        width: unset;
+        min-width: var(--sz-graph-filter-match-key-tags-min-width);
+        padding: 0 3px;
       }
     }
   }

--- a/src/lib/graph/sz-graph-filter.component.scss
+++ b/src/lib/graph/sz-graph-filter.component.scss
@@ -54,6 +54,10 @@
         cursor: pointer;
       }
     }
+
+    &.match-key-token-filter-header h3 {
+      margin-bottom: 0;
+    }
   }
 
   hr {
@@ -146,6 +150,7 @@
 
   .match-key-token-mode-select {
     display: block;
+    margin-bottom: 20px;
   }
 
   mat-chip-list.match-keys {

--- a/src/lib/graph/sz-graph-filter.component.scss
+++ b/src/lib/graph/sz-graph-filter.component.scss
@@ -135,6 +135,19 @@
     }
   }
 
+  .chip-group {
+    &.core {
+      border: 1px solid salmon;
+    }
+    &.extraneous {
+      border: 1px solid lightblue;
+    }
+  }
+
+  .match-key-token-mode-select {
+    display: block;
+  }
+
   mat-chip-list.match-keys {
 
     mat-chip {

--- a/src/lib/graph/sz-graph-filter.component.ts
+++ b/src/lib/graph/sz-graph-filter.component.ts
@@ -79,7 +79,9 @@ export class SzGraphFilterComponent implements OnInit, AfterViewInit, OnDestroy 
   }
   @Input() set unlimitedMaxScope(value: boolean | string) {
     if(value === undefined) return;
-    this.prefs.graph.unlimitedMaxScope = parseBool(value);
+    if(this.prefs.graph.unlimitedMaxScope !== parseBool(value)) {
+      this.prefs.graph.unlimitedMaxScope = parseBool(value);
+    }
   }
   get unlimitedMaxScope(): boolean {
     return this.prefs.graph.unlimitedMaxScope;
@@ -512,8 +514,10 @@ export class SzGraphFilterComponent implements OnInit, AfterViewInit, OnDestroy 
    * this handler is invoked to set the appropriate preferences.
    */
   public onMaxUnlimitedChange(prefKey: string, value: boolean) {
-    console.log('onMaxUnlimitedChange: ', value);
-    this.prefs.graph[ prefKey ] = value;
+    //console.log('onMaxUnlimitedChange: ', value);
+    if(this.prefs.graph[ prefKey ] !== value) {   // prevents recursive change evt loops
+      this.prefs.graph[ prefKey ] = value;
+    }
   }
 
   /** proxy handler for when prefs have changed externally */
@@ -593,6 +597,11 @@ export class SzGraphFilterComponent implements OnInit, AfterViewInit, OnDestroy 
 
   /** toggle all available match key tokens on or off */
   onSelectAllMatchKeyTokens(selectAll: boolean) {
+    /**
+     * @TODO something about changing this is causing a new 
+     * graph data request. Need to fix this.
+     */
+    console.log('@senzing/sdk-components-ng/sz-entity-detail-graph-filter.onSelectAllMatchKeyTokens: ', selectAll);
     if(this.showCoreMatchKeyTokenChips) {
       this.prefs.graph.matchKeyCoreTokensIncluded = selectAll ? this.matchKeyCoreTokens.map((token: SzMatchKeyTokenComposite) => { return token.name; }) : [];
     } else if(this.prefs.graph.matchKeyCoreTokensIncluded && this.prefs.graph.matchKeyCoreTokensIncluded.length > 0) {

--- a/src/lib/graph/sz-graph-filter.component.ts
+++ b/src/lib/graph/sz-graph-filter.component.ts
@@ -799,5 +799,13 @@ export class SzGraphFilterComponent implements OnInit, AfterViewInit, OnDestroy 
     return true;
     return (this.showMatchKeyTokens && this.showMatchKeyTokens.length > 0) ? (this.showMatchKeyTokens.findIndex( (mkCat)=> { return mkCat.name === mkName; } ) > -1) : true;
   }
+  /** function for shortening the match key token badge counts notation */
+  public getMKBadgeCount(count: number): string {
+    let retVal = (count && count > 0) ? (count as unknown as string) : '0';
+    if (count >= 1000) {
+      retVal = (Math.round((count / 1000) * 10) / 10)+'K';
+    }
+    return retVal;
+  }
   
 }

--- a/src/lib/graph/sz-graph.component.html
+++ b/src/lib/graph/sz-graph.component.html
@@ -27,6 +27,7 @@
       (relationshipContextMenuClick)="onLinkRightClick($event)"
       (noResults)="onNoResults($event)"
       (onDataLoaded)="onGraphDataLoaded($event)"
+      (onPreflightRequestComplete)="onPreflightRequestComplete($event)"
       (scaleChanged)="onGraphZoom($event)"
       [maxEntities]="maxEntities"></sz-relationship-network>
   
@@ -51,6 +52,7 @@
         [showMatchKeyTokenSelectAll]="showMatchKeyTokenSelectAll"
         [showCoreMatchKeyTokenChips]="showCoreMatchKeyTokenChips"
         [showExtraneousMatchKeyTokenChips]="showExtraneousMatchKeyTokenChips"
+        [maxEntitiesLimit]="maxEntitiesFilterLimit"
       ></sz-graph-filter>
   
       <svg class="popout-icon"

--- a/src/lib/graph/sz-graph.component.ts
+++ b/src/lib/graph/sz-graph.component.ts
@@ -4,11 +4,10 @@ import { takeUntil } from 'rxjs/operators';
 import { Subject } from 'rxjs';
 import { SzEntityData, SzEntityIdentifier, SzEntityNetworkData } from '@senzing/rest-api-client-ng';
 import { SzGraphControlComponent } from './sz-graph-control.component';
-import { SzGraphNodeFilterPair, SzEntityNetworkMatchKeyTokens } from '../models/graph';
+import { SzGraphNodeFilterPair, SzEntityNetworkMatchKeyTokens, SzMatchKeyTokenComposite, SzNetworkGraphInputs, SzMatchKeyTokenFilterScope } from '../models/graph';
 import { SzRelationshipNetworkComponent } from './sz-relationship-network/sz-relationship-network.component';
 import { parseBool, parseSzIdentifier, sortDataSourcesByIndex } from '../common/utils';
 import { SzDataSourceComposite } from '../models/data-sources';
-import { SzMatchKeyTokenComposite, SzNetworkGraphInputs, SzMatchKeyTokenFilterScope } from '../models/graph';
 
 /**
  * Embeddable Graph Component
@@ -192,7 +191,7 @@ export class SzGraphComponent implements OnInit, OnDestroy {
   @Input() public showMatchKeyTokenSelectAll: boolean       = true;
 
   /** @internal */
-  private _showCoreMatchKeyTokenChips: boolean              = false;
+  protected _showCoreMatchKeyTokenChips: boolean              = false;
   /**
    * whether or not to show only the match key token chips that apply 
    * to "core" relationships. ie if the relationship is only between 
@@ -213,7 +212,7 @@ export class SzGraphComponent implements OnInit, OnDestroy {
     return this._showCoreMatchKeyTokenChips;
   }
   /** @internal */
-  private _showExtraneousMatchKeyTokenChips: boolean = true;
+  protected _showExtraneousMatchKeyTokenChips: boolean = true;
   /**
    * whether or not to show only match key token chips that apply 
    * to relationships between entities that are NOT directly related to 
@@ -256,6 +255,14 @@ export class SzGraphComponent implements OnInit, OnDestroy {
     } else {
       this._matchKeyTokenSelectionScope = (value as SzMatchKeyTokenFilterScope);
     }
+    /*
+    if(this._matchKeyTokenSelectionScope !== SzMatchKeyTokenFilterScope.EXTRANEOUS) {
+      this._showExtraneousMatchKeyTokenChips = false;
+    }
+    if(this._matchKeyTokenSelectionScope !== SzMatchKeyTokenFilterScope.CORE) {
+      this._showCoreMatchKeyTokenChips        = false;
+    }*/
+
     //console.log(`@senzing/sdk-components-ng/sz-graph-component.matchKeyTokenSelectionScope(${value} | ${(this._matchKeyTokenSelectionScope as unknown as string)})`, this._matchKeyTokenSelectionScope);
   }
   /**

--- a/src/lib/graph/sz-graph.component.ts
+++ b/src/lib/graph/sz-graph.component.ts
@@ -417,6 +417,7 @@ export class SzGraphComponent implements OnInit, OnDestroy {
    * Observeable stream for the event that occurs when a draw
    * operation is completed
    */
+  @Output() public renderStarted: EventEmitter<boolean> = new EventEmitter<boolean>();
   @Output() public renderComplete: EventEmitter<boolean> = new EventEmitter<boolean>();
   /**
    * Observeable stream for the event that occurs when a
@@ -707,6 +708,23 @@ export class SzGraphComponent implements OnInit, OnDestroy {
     }
   }
 
+  onDataLoaded(data) {
+    console.log('onDataLoaded: ', data);
+  }
+
+  onRenderStarted(state) {
+    console.log('[STANDALONE GRAPH] onRenderStarted', state);
+    this.renderStarted.emit(state);
+  }
+  onRenderCompleted(state) {
+    console.log('[STANDALONE GRAPH] onRenderCompleted', state);
+    this.renderComplete.emit(state);
+  }
+  onRequestCompleted(state) {
+    console.log('[STANDALONE GRAPH] onRequestCompleted', state);
+    this.renderComplete.emit(state);
+  }
+
   constructor(
     public prefs: SzPrefsService,
     private cd: ChangeDetectorRef
@@ -746,21 +764,22 @@ export class SzGraphComponent implements OnInit, OnDestroy {
       this.graphNetworkComponent.requestStarted.pipe(
         takeUntil(this.unsubscribe$)
       ).subscribe( (args) => {
-        //console.log('[STANDALONE GRAPH] requestStarted', args);
+        console.log('[STANDALONE GRAPH] requestStarted', args);
         this.requestStarted.emit(args);
       });
       this.graphNetworkComponent.requestComplete.pipe(
         takeUntil(this.unsubscribe$)
       ).subscribe( (args) => {
+        console.log('[STANDALONE GRAPH] requestComplete', args);
         this.requestComplete.emit(args);
       });
       this.graphNetworkComponent.renderComplete.pipe(
         takeUntil(this.unsubscribe$)
       ).subscribe( (args) => {
-          //console.log('[STANDALONE GRAPH] renderComplete', args);
+          console.log('[STANDALONE GRAPH] renderComplete', args);
         this.renderComplete.emit(args);
       });
-      this.graphNetworkComponent.requestNoResults.pipe(
+      this.graphNetworkComponent.noResults.pipe(
         takeUntil(this.unsubscribe$)
       ).subscribe( (args) => {
         this.requestNoResults.emit(args);
@@ -769,7 +788,7 @@ export class SzGraphComponent implements OnInit, OnDestroy {
       this.graphNetworkComponent.onDataLoaded.pipe(
         takeUntil(this.unsubscribe$)
       ).subscribe( (args) => {
-          //console.log('[STANDALONE GRAPH] onDataLoaded', args);
+          console.log('[STANDALONE GRAPH] onDataLoaded', args);
           this.dataLoaded.emit(args.data);
       });
       this.graphNetworkComponent.onDataRequested.pipe(

--- a/src/lib/graph/sz-graph.component.ts
+++ b/src/lib/graph/sz-graph.component.ts
@@ -764,19 +764,19 @@ export class SzGraphComponent implements OnInit, OnDestroy {
       this.graphNetworkComponent.requestStarted.pipe(
         takeUntil(this.unsubscribe$)
       ).subscribe( (args) => {
-        console.log('[STANDALONE GRAPH] requestStarted', args);
+        //console.log('[STANDALONE GRAPH] requestStarted', args);
         this.requestStarted.emit(args);
       });
       this.graphNetworkComponent.requestComplete.pipe(
         takeUntil(this.unsubscribe$)
       ).subscribe( (args) => {
-        console.log('[STANDALONE GRAPH] requestComplete', args);
+        //console.log('[STANDALONE GRAPH] requestComplete', args);
         this.requestComplete.emit(args);
       });
       this.graphNetworkComponent.renderComplete.pipe(
         takeUntil(this.unsubscribe$)
       ).subscribe( (args) => {
-          console.log('[STANDALONE GRAPH] renderComplete', args);
+        //console.log('[STANDALONE GRAPH] renderComplete', args);
         this.renderComplete.emit(args);
       });
       this.graphNetworkComponent.noResults.pipe(
@@ -788,7 +788,7 @@ export class SzGraphComponent implements OnInit, OnDestroy {
       this.graphNetworkComponent.onDataLoaded.pipe(
         takeUntil(this.unsubscribe$)
       ).subscribe( (args) => {
-          console.log('[STANDALONE GRAPH] onDataLoaded', args);
+          //console.log('[STANDALONE GRAPH] onDataLoaded', args);
           this.dataLoaded.emit(args.data);
       });
       this.graphNetworkComponent.onDataRequested.pipe(

--- a/src/lib/graph/sz-relationship-network/sz-relationship-network.component.ts
+++ b/src/lib/graph/sz-relationship-network/sz-relationship-network.component.ts
@@ -322,34 +322,43 @@ export class SzRelationshipNetworkComponent implements AfterViewInit, OnDestroy 
   private _buildOut: number | undefined;
   @Input() set buildOut(value: string| number) { this._buildOut = +value; }
 
-  /**
-   * maxiumum entities to display
-   */
+  /** @internal */
   private _maxEntities: number | undefined;
+  /** @internal */
   private _maxEntitiesPreflightLimit: number | undefined;
+  /** the maximum entities to pull back from the api request */
   @Input() set maxEntities(value: string | number) { 
     this._maxEntities = parseInt(value as string); 
   }
+  /** the maximum entities to pull back from the api request */
   public get maxEntities(): number {
     return this._maxEntities;
   }
-
+  /** @internal */
   private _unlimitedMaxEntities: boolean = false;
+  /** sets whether or not to ignore the value set in "maxEntities" */
   @Input() public set noMaxEntitiesLimit(value: boolean | string) {
     this._unlimitedMaxEntities = parseBool(value as string);
   }
+  /** whether or not to ignore the value set in "maxEntities" */
   public get noMaxEntitiesLimit(): boolean {
     return this._unlimitedMaxEntities;
   }
+  /** @internal */
   private _unlimitedMaxScope: boolean = false;
+  /** sets whether or not to ignore the value set in "buildOut" */
   @Input() public set noMaxScopeLimit(value: boolean | string) {
     this._unlimitedMaxScope = parseBool(value as string);
   }
+  /** whether or not to ignore the value set in "buildOut" */
   public get noMaxScopeLimit(): boolean {
     return this._unlimitedMaxScope;
   }
-
+  /** when a preflight request completes */
   @Output() onPreflightRequestComplete: EventEmitter<any> = new EventEmitter<any>();
+  /** when the initial or preflight request has the total relationships available
+   * this event is emitted.
+  */
   @Output() onTotalRelationshipsCountUpdated: EventEmitter<number> = new EventEmitter<number>();
 
   /**
@@ -1316,8 +1325,8 @@ export class SzRelationshipNetworkComponent implements AfterViewInit, OnDestroy 
       _parametersChanged = true;
     }
 
-    console.log(`getNetwork(${entityIds},${maxDegrees},${buildOut},${maxEntities} | ${this.maxEntities}) | ${this._unlimitedMaxEntities}`, 
-    _parametersChanged);
+    //console.log(`getNetwork(${entityIds},${maxDegrees},${buildOut},${maxEntities} | ${this.maxEntities}) | ${this._unlimitedMaxEntities}`, 
+    //_parametersChanged);
 
     this._lastPrimaryRequestParameters = _lastPrimaryRequestParameters;
     if(

--- a/src/lib/scss/theme.scss
+++ b/src/lib/scss/theme.scss
@@ -356,10 +356,11 @@ body {
     --sz-graph-filter-match-key-tags-align-items: flex-start;
     --sz-graph-filter-match-key-tags-font-size: 10px;
     --sz-graph-filter-match-key-tags-line-height: inherit;
-    --sz-graph-filter-match-key-tags-padding: 4px 30px 4px 12px;
+    --sz-graph-filter-match-key-tags-padding: 4px 40px 4px 12px;
     --sz-graph-filter-match-key-tags-margin-right: 20px;
     --sz-graph-filter-match-key-tags-width: unset;
     --sz-graph-filter-match-key-tags-min-height: 26px;
+    --sz-graph-filter-match-key-tags-min-width: 22px;
     --sz-graph-filter-match-key-tags-color: #525252;
     --sz-graph-filter-match-key-tags-background-color: #e0e0e0;
     --sz-graph-filter-match-key-tags-cursor: pointer;

--- a/src/lib/sdk.material.module.ts
+++ b/src/lib/sdk.material.module.ts
@@ -13,6 +13,7 @@ import { MatInputModule } from '@angular/material/input'
 import { MatMenuModule } from '@angular/material/menu';
 import { MatPaginatorModule } from '@angular/material/paginator';
 import { MatSidenavModule } from '@angular/material/sidenav';
+import { MatSliderModule } from '@angular/material/slider';
 import { MatSlideToggleModule } from '@angular/material/slide-toggle';
 import { MatSortModule } from '@angular/material/sort';
 import { MatTableModule } from '@angular/material/table';
@@ -36,6 +37,7 @@ import { NoopAnimationsModule } from '@angular/platform-browser/animations';
     MatMenuModule, 
     MatPaginatorModule, 
     MatSidenavModule, 
+    MatSliderModule,
     MatSlideToggleModule,
     MatSortModule, 
     MatTableModule, 
@@ -56,6 +58,7 @@ import { NoopAnimationsModule } from '@angular/platform-browser/animations';
     MatMenuModule,
     MatPaginatorModule, 
     MatSidenavModule, 
+    MatSliderModule,
     MatSlideToggleModule,
     MatSortModule, 
     MatTableModule, 

--- a/src/lib/sdk.material.module.ts
+++ b/src/lib/sdk.material.module.ts
@@ -1,29 +1,67 @@
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { DragDropModule } from '@angular/cdk/drag-drop';
-import { MatInputModule } from '@angular/material/input'
 import { MatBadgeModule } from '@angular/material/badge';
 import { MatBottomSheetModule } from '@angular/material/bottom-sheet';
 import { MatButtonModule } from '@angular/material/button';
 import { MatCheckboxModule } from '@angular/material/checkbox';
+import { MatChipsModule } from '@angular/material/chips'
 import { MatDialogModule } from '@angular/material/dialog';
-import { MatToolbarModule } from '@angular/material/toolbar';
-import { MatTooltipModule } from '@angular/material/tooltip';
-import { MatMenuModule } from '@angular/material/menu';
-import { MatIconModule } from '@angular/material/icon';
 import { MatGridListModule } from '@angular/material/grid-list';
-import { MatTableModule } from '@angular/material/table';
-import { MatSortModule } from '@angular/material/sort';
+import { MatIconModule } from '@angular/material/icon';
+import { MatInputModule } from '@angular/material/input'
+import { MatMenuModule } from '@angular/material/menu';
 import { MatPaginatorModule } from '@angular/material/paginator';
 import { MatSidenavModule } from '@angular/material/sidenav';
+import { MatSlideToggleModule } from '@angular/material/slide-toggle';
+import { MatSortModule } from '@angular/material/sort';
+import { MatTableModule } from '@angular/material/table';
+import { MatToolbarModule } from '@angular/material/toolbar';
+import { MatTooltipModule } from '@angular/material/tooltip';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
-import { MatChipsModule } from '@angular/material/chips'
 
 @NgModule({
   declarations: [],
-  imports: [ NoopAnimationsModule, DragDropModule, MatDialogModule, MatBadgeModule, MatBottomSheetModule, MatChipsModule, MatInputModule, MatTableModule, MatPaginatorModule, MatSortModule, MatSidenavModule, MatButtonModule, MatCheckboxModule, MatToolbarModule, MatTooltipModule, MatMenuModule, MatIconModule, MatGridListModule],
+  imports: [ 
+    DragDropModule, 
+    MatBadgeModule, 
+    MatBottomSheetModule, 
+    MatButtonModule, 
+    MatCheckboxModule, 
+    MatChipsModule, 
+    MatDialogModule, 
+    MatGridListModule,
+    MatIconModule, 
+    MatInputModule, 
+    MatMenuModule, 
+    MatPaginatorModule, 
+    MatSidenavModule, 
+    MatSlideToggleModule,
+    MatSortModule, 
+    MatTableModule, 
+    MatToolbarModule, 
+    MatTooltipModule, 
+    NoopAnimationsModule],
   exports: [ 
-    DragDropModule, MatDialogModule, MatBadgeModule, MatBottomSheetModule, MatChipsModule, MatInputModule, MatTableModule, MatPaginatorModule, MatSortModule, MatSidenavModule, MatButtonModule, MatCheckboxModule, MatToolbarModule, MatTooltipModule, MatMenuModule, MatIconModule, MatGridListModule
+    DragDropModule, 
+    MatBadgeModule, 
+    MatBottomSheetModule, 
+    MatButtonModule, 
+    MatCheckboxModule, 
+    MatChipsModule, 
+    MatDialogModule,
+    MatGridListModule, 
+    MatIconModule,
+    MatInputModule, 
+    MatMenuModule,
+    MatPaginatorModule, 
+    MatSidenavModule, 
+    MatSlideToggleModule,
+    MatSortModule, 
+    MatTableModule, 
+    MatToolbarModule, 
+    MatTooltipModule,
+    NoopAnimationsModule
   ],
 })
 export class SzSdkMaterialModule { }

--- a/src/lib/services/sz-prefs.service.ts
+++ b/src/lib/services/sz-prefs.service.ts
@@ -879,6 +879,10 @@ export class SzGraphPrefs extends SzSdkPrefsBase {
   private _neverFilterQueriedEntityIds: boolean = true;
   /** @internal */
   private _queriedEntitiesColor: string | undefined = "#465BA8";
+  /** @internal */
+  private _unlimitedMaxEntities: boolean = true;
+  /** @internal */
+  private _unlimitedMaxScope: boolean = false;
 
   /** the keys of member setters or variables in the object
    * to output in json, or to take as json input
@@ -897,7 +901,9 @@ export class SzGraphPrefs extends SzSdkPrefsBase {
     'matchKeyTokensIncluded',
     'matchKeyCoreTokensIncluded',
     'neverFilterQueriedEntityIds',
-    'queriedEntitiesColor'
+    'queriedEntitiesColor',
+    'unlimitedMaxEntities',
+    'unlimitedMaxScope'
   ]
 
   // -------------- getters and setters
@@ -1032,7 +1038,28 @@ export class SzGraphPrefs extends SzSdkPrefsBase {
     this._queriedEntitiesColor = value;
     if(!this.bulkSet) this.prefsChanged.next( this.toJSONObject() );
   }
-
+  /** whether or not to ignore the maxEntities value and always get 
+   * all related entities */
+  public get unlimitedMaxEntities(): boolean {
+    return this._unlimitedMaxEntities;
+  }
+  /** whether or not to ignore the maxEntities value and always get 
+   * all related entities */
+  public set unlimitedMaxEntities(value: boolean) {
+    this._unlimitedMaxEntities = value;
+    if(!this.bulkSet && this._rememberStateOptions) this.prefsChanged.next( this.toJSONObject() );
+  }
+  /** whether or not to ignore the maxDegreesOfSeparation value and always get 
+   * build out to max */
+   public get unlimitedMaxScope(): boolean {
+    return this._unlimitedMaxScope;
+  }
+  /** whether or not to ignore the maxDegreesOfSeparation value and always get 
+   * build out to max */
+  public set unlimitedMaxScope(value: boolean) {
+    this._unlimitedMaxScope = value;
+    if(!this.bulkSet && this._rememberStateOptions) this.prefsChanged.next( this.toJSONObject() );
+  }
 
   /**
    * publish out a "first" real payload so that

--- a/src/package.json
+++ b/src/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@senzing/sdk-components-ng",
-  "version": "5.0.1-beta.1",
+  "version": "5.1.0-beta.0",
   "private": false,
   "keywords" :["Angular","Library","Senzing"],
   "license" : "SEE LICENSE IN LICENSE",


### PR DESCRIPTION
# Pull request questions

## Which issue does this address

![image](https://user-images.githubusercontent.com/13721038/180916621-aabe3eb1-2a15-4ccf-bde3-e7bed8e1ed4f.png)![image](https://user-images.githubusercontent.com/13721038/180922551-53347041-47d9-44c4-b04f-eb5649cc37ae.png)

resolves #347 
resolves #350 
resolves #355 

## Why was change needed

### Added
- the following event emitters added to `SzGraphFilterComponent`
  - `matchKeyTokenSelectionScopeChanged` when the user switches from `CORE` to `EXTRANEOUS` match key token scope
- the following getters and setters added to `SzGraphFilterComponent`
  -  `maxEntitiesLimit` the maximum value that the slider control will allow. default is 200.
  -  `unlimitedMaxEntities` ignore the `maxEntities` value and always pull up to 40000
  -  `unlimitedMaxScope` ignore the `buildOut` value and always pull up to 10
- the following getters and setters added to `SzGraphComponent`
  - `unlimitedMaxEntities`
  - `unlimitedMaxScope`
  - `maxEntitiesFilterLimit`
- the following event emitters on `SzGraphComponent`
  - `renderStarted` not sure why this didn't exist since `renderComplete` did
  - `dataLoading` for more flexible state sensing
  - `onPreflightRequestComplete` so we can get the total relationship count to populate the `maxEntitiesFilterLimit`
- the following properties/getters/setters added to `SzRelationshipNetworkComponent`
  - `noMaxEntitiesLimit` sets whether or not to ignore the value set in `maxEntities`
  - `noMaxScopeLimit` sets whether or not to ignore the value set in `buildOut`
- the following event emitters added to `SzRelationshipNetworkComponent`
  - `onTotalRelationshipsCountUpdated` is emitted with the value of how many total relationships are possible to display according to the data in the focal entities related entities.
  - `renderStarted` wasn't wired correctly. works now
  - `dataLoading` when a data request has been initiated.
  - `dataLoaded` which is like `requestComplete` but instead of a boolean it returns the data response
- the following preferences added to `SzGraphPrefs`
  - `unlimitedMaxEntities`
  - `unlimitedMaxScope`
- `getEntitiesByIds` method added to `SzSearchService` to get data for multiple entities by their id's in the form of `Observable<SzEntityData[]>`

### Modified
- the following getters and setters added to `SzGraphFilterComponent`
  - `maxEntities` the maximum number of entities to display on the graph
- the following changes made to `SzRelationshipNetworkComponent`
  - `dataRequested` changed to BehaviorSubject (lifecycle bugfix)
  - `requestStarted` fixed
  - `requestComplete` fixed
  - `getNetwork` signature changed to `getNetwork(entityIds: SzEntityIdentifier[], maxDegrees: number, buildOut: number, maxEntities: number)`
  - the following event emitters have been rewired so that they are just proxies of 
the observeable event streams for uniformity/reliability:
    - `onRequestStarted`
    - `onRequestCompleted`
    - `onRenderStarted`
    - `onRenderCompleted`
    - `onNoResults`
    - `onDataRequested`
    - `onDataLoaded`
    - `onDataUpdated`
    - `scaleChanged`

## What does change improve

- there is now a new `unlimited` ui option for maximum entities allowed.
- there is now a new `unlimited` ui option for maximum build out allowed.
- the upper limit of the maximum entities ui slider is now dynamically set from the initial query.
- match key token counts now feature condensed notation instead of ellipsis
- lifecycle events audited and patched
  - requestStarted
  - requestComplete
