### PR TITLE
#358 fix for core rel match key filtering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - there is now a new `unlimited` ui option for maximum entities allowed.
 - there is now a new `unlimited` ui option for maximum build out allowed.
 - the upper limit of the maximum entities ui slider is now dynamically set from the initial query.
-- match key token counts now feature condensed notation instead of ellipsis
+- match key token counts now feature condensed notation instead of ellipsis.
 
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,7 +67,7 @@ the observeable event streams for uniformity/reliability:
     - `onDataUpdated`
     - `scaleChanged`
 
-relevant tickets: #343 #344 #347 #348 #350 #355
+relevant tickets: #343 #344 #347 #348 #350 #355 #358
 
 ## [5.0.0] - 2022-07-01
 

--- a/src/lib/graph/sz-graph.component.ts
+++ b/src/lib/graph/sz-graph.component.ts
@@ -148,7 +148,16 @@ export class SzGraphComponent implements OnInit, OnDestroy {
   get unlimitedMaxScope(): boolean {
     return this.prefs.graph.unlimitedMaxScope;
   }
-  @Input() buildOut: number = 0;
+  /* @internal */
+  private _buildOut: number = 1;
+  /** the level of degrees from focus that the query will attempt to resolve */
+  @Input() set buildOut(value: number) {
+    this._buildOut = value > 0 ? value : 1;
+  }
+  /** the level of degrees from focus that the query will attempt to resolve */
+  public get buildOut(): number {
+    return this._buildOut > 0 ? this._buildOut : 1;
+  }
   /** array of datasources with color and order information */
   @Input() public set dataSourceColors(value: SzDataSourceComposite[]) {
     this._dataSourceColors  = value;
@@ -1090,15 +1099,16 @@ export class SzGraphComponent implements OnInit, OnDestroy {
     } else if(coreMatchKeyTokens && this._matchKeyTokenSelectionScope === SzMatchKeyTokenFilterScope.CORE) {
       if(coreMatchKeyTokens && coreMatchKeyTokens.length === 0) {
         // just hide everything that is 1 lvl deep
-        if(nodeData && (nodeData.isRelatedToPrimaryEntity || nodeData.relatedToPrimaryEntityDirectly || nodeData.isPrimaryEntity) && nodeData.relationshipMatchKeyTokens && nodeData.relationshipMatchKeyTokens.indexOf) {
+        //if(nodeData && (nodeData.isRelatedToPrimaryEntity || nodeData.relatedToPrimaryEntityDirectly || nodeData.isPrimaryEntity) && nodeData.relationshipMatchKeyTokens && nodeData.relationshipMatchKeyTokens.indexOf) {
+        if(nodeData && (nodeData.isRelatedToPrimaryEntity || nodeData.relatedToPrimaryEntityDirectly || nodeData.isPrimaryEntity) && nodeData.coreRelationshipMatchKeyTokens && nodeData.coreRelationshipMatchKeyTokens.indexOf) {
           retVal = false;
         } else {
           retVal = true;
         }
         // and show everything else
-      } else if(nodeData && (nodeData.isRelatedToPrimaryEntity || nodeData.relatedToPrimaryEntityDirectly || nodeData.isPrimaryEntity) && nodeData.relationshipMatchKeyTokens && nodeData.relationshipMatchKeyTokens.indexOf){
+      } else if(nodeData && (nodeData.isRelatedToPrimaryEntity || nodeData.relatedToPrimaryEntityDirectly || nodeData.isPrimaryEntity) && nodeData.coreRelationshipMatchKeyTokens && nodeData.coreRelationshipMatchKeyTokens.indexOf){
         // D3 filter query 
-        retVal = (nodeData.relationshipMatchKeyTokens.some( (tokenName) => {
+        retVal = (nodeData.coreRelationshipMatchKeyTokens.some( (tokenName) => {
           return coreMatchKeyTokens.indexOf(tokenName) > -1;
         }));
         //console.log(`isMatchKeyTokenInEntityNode: checking for "${coreMatchKeyTokens}"? ${retVal}`, nodeData.relationshipMatchKeyTokens, );

--- a/src/lib/graph/sz-relationship-network/sz-relationship-network.component.ts
+++ b/src/lib/graph/sz-relationship-network/sz-relationship-network.component.ts
@@ -2514,6 +2514,29 @@ export class SzRelationshipNetworkComponent implements AfterViewInit, OnDestroy 
     if(d.phone && d.phone !== null) {
       retVal += "<br/><strong>Phone</strong>: " + d.phone;
     }
+    /*
+    if(d.relationshipMatchKeys) {
+      retVal += "<br/><strong>match key</strong>: <br/>";
+      retVal += `<li>${d.relationshipMatchKeys}</li>`;
+    }
+    if(d.relationshipMatchKeyTokens && d.relationshipMatchKeyTokens.forEach) {
+      retVal += "<br/><strong>match keys</strong>: <br/>";
+      retVal += "<ul>";
+      d.relationshipMatchKeyTokens.forEach((mkt) =>{
+        retVal += `<li>${mkt}</li>`;
+      });
+      retVal += "</ul>";
+    }
+    if(d.coreRelationshipMatchKeyTokens && d.coreRelationshipMatchKeyTokens.forEach && d.coreRelationshipMatchKeyTokens.length > 0) {
+      retVal += "<br/><strong>core match keys</strong>: <br/>";
+      retVal += "<ul>";
+      d.coreRelationshipMatchKeyTokens.forEach((mkt) =>{
+        retVal += `<li>${mkt}</li>`;
+      });
+      retVal += "</ul>";
+    }*/
+    //console.log('tt match key categories by entity id: ', d.matchKeyCategoriesByEntityId[d.entityId], d.coreRelationshipMatchKeyTokens[ d.entityId ]);
+    
     //retVal += "<br/><strong>areAllRelatedEntitiesOnDeck(1)</strong>: "+ d.allRelatedEntitiesOnDeck;
     //retVal += "<br/><strong>numberRelated</strong>: "+ d.numberRelated;
     //retVal += "<br/><strong>numberRelatedOnDeck</strong>: "+ d.numberRelatedOnDeck;
@@ -2940,9 +2963,12 @@ export class SzRelationshipNetworkComponent implements AfterViewInit, OnDestroy 
     const primaryEntityIds = this._entityIds ? this._entityIds : [];
     const coreEntityIds = [];
     const coreLinkIds = [];
-    const primaryEntities = this._entityIds.map( parseInt );
+    const primaryEntities = this._entityIds && this._entityIds.map ? this._entityIds.map( (_val) => {
+      return parseInt(_val)
+    }) : [];
     const relatedMatchKeysByEntityId: {[key: number]: string[]} = {};
     const matchKeyCategoriesByEntityId: {[key: number]: string[]} = {};
+    const matchKeyCoreCategoriesByEntityId: {[key: number]: string[]} = {};
 
     // grab the directly related to core node entity Ids first
     let   relatedToPrimaryEntities = [];
@@ -2985,6 +3011,25 @@ export class SzRelationshipNetworkComponent implements AfterViewInit, OnDestroy 
         entNode.relatedEntities.forEach((_relatedEnt: SzRelatedEntity) => {
           let _relatedEntId = _relatedEnt.entityId;
           let _relatedMatchCategory = SzRelationshipNetworkComponent.tokenizeMatchKey(_relatedEnt.matchKey);
+          let _relatedEntityIsPrimary = primaryEntities.indexOf(_relatedEntId) > -1 || primaryEntities.indexOf(_resolvedEntId) > -1;
+          if(_relatedEntityIsPrimary) {
+            // this is a core relationship
+            if(!matchKeyCoreCategoriesByEntityId[ _relatedEntId ] || matchKeyCoreCategoriesByEntityId[ _relatedEntId ] === undefined) {
+              matchKeyCoreCategoriesByEntityId[ _relatedEntId ] = [];
+            }
+            if(matchKeyCoreCategoriesByEntityId[ _relatedEntId ] && matchKeyCoreCategoriesByEntityId[ _relatedEntId ].concat) {
+              let concatVals = [];
+              _relatedMatchCategory.forEach((mkArr) => {
+                concatVals = concatVals.concat(mkArr);
+              });
+
+              matchKeyCoreCategoriesByEntityId[ _relatedEntId ] = matchKeyCoreCategoriesByEntityId[ _relatedEntId ].concat(concatVals);
+              // de-dupe values
+              matchKeyCoreCategoriesByEntityId[ _relatedEntId ] = matchKeyCoreCategoriesByEntityId[ _relatedEntId ].filter((value, index, self) => {
+                return self.indexOf(value) === index;
+              });
+            }
+          }
 
           if(!relatedMatchKeysByEntityId[ _relatedEntId ] || relatedMatchKeysByEntityId[ _relatedEntId ] === undefined) {
             relatedMatchKeysByEntityId[ _relatedEntId ] = [];
@@ -3020,6 +3065,7 @@ export class SzRelationshipNetworkComponent implements AfterViewInit, OnDestroy 
       let isPrimaryEntity                 = primaryEntityIds.includes( (entityId as unknown as string)+"")
       let relatedMatchKeys                = relatedMatchKeysByEntityId[ resolvedEntity.entityId ]   ? relatedMatchKeysByEntityId[ resolvedEntity.entityId ]     : [];
       let relatedMatchKeyCategories       = matchKeyCategoriesByEntityId[ resolvedEntity.entityId ] ? matchKeyCategoriesByEntityId[ resolvedEntity.entityId ]   : [];
+      let coreRelatedMatchKeyCategories   = matchKeyCoreCategoriesByEntityId[ resolvedEntity.entityId ] ? matchKeyCoreCategoriesByEntityId[ resolvedEntity.entityId ]   : [];
       let relatedToPrimaryEntityDirectly  = primaryEntityIds.includes( (entityId as unknown as string)+"") ? true : false;
       let hasCollapsibleRelationships     = false;
       if(relatedEntities && !isPrimaryEntity) {
@@ -3084,6 +3130,8 @@ export class SzRelationshipNetworkComponent implements AfterViewInit, OnDestroy 
         resolvedEntityData: resolvedEntity,
         nodesVisibleBeforeExpand: [],
         relationshipMatchKeyTokens: relatedMatchKeyCategories,
+        coreRelationshipMatchKeyTokens: coreRelatedMatchKeyCategories,
+        matchKeyCategoriesByEntityId: matchKeyCategoriesByEntityId,
         styles: [],
         visibilityClass: undefined
       });

--- a/src/lib/graph/sz-relationship-network/sz-relationship-network.component.ts
+++ b/src/lib/graph/sz-relationship-network/sz-relationship-network.component.ts
@@ -3102,6 +3102,7 @@ export class SzRelationshipNetworkComponent implements AfterViewInit, OnDestroy 
       nodes.push({
         address: resolvedEntity.addressData && resolvedEntity.addressData.length > 0 ? resolvedEntity.addressData[0] : SzRelationshipNetworkComponent.firstOrNull(features, "ADDRESS"),
         areAllRelatedEntitiesOnDeck: false,
+        coreRelationshipMatchKeyTokens: coreRelatedMatchKeyCategories,
         dataSources: resolvedEntity.recordSummaries.map((ds) =>  ds.dataSource ),
         entityId: entityId,
         hasCollapsedRelationships: relatedToPrimaryEntityDirectly && (relatedEntities && relatedEntities.length > 0),
@@ -3115,6 +3116,7 @@ export class SzRelationshipNetworkComponent implements AfterViewInit, OnDestroy 
         isRemovable: (!coreEntityIds.includes(entityId) && !primaryEntityIds.includes( (entityId as unknown as string)+"") && !queriedEntityIds.includes(entityId)),
         isQueriedNode: queriedEntityIds.includes(entityId),
         name: resolvedEntity.entityName,
+        nodesVisibleBeforeExpand: [],
         numberRelated: relatedEntities ? relatedEntities.length : 0,
         numberRelatedOnDeck: 0,
         numberRelatedHidden: relatedEntities ? relatedEntities.length : 0,
@@ -3128,10 +3130,7 @@ export class SzRelationshipNetworkComponent implements AfterViewInit, OnDestroy 
         relatedEntitiesData: relatedEntities,
         relatedVisibleBeforeExpand: [],
         resolvedEntityData: resolvedEntity,
-        nodesVisibleBeforeExpand: [],
         relationshipMatchKeyTokens: relatedMatchKeyCategories,
-        coreRelationshipMatchKeyTokens: coreRelatedMatchKeyCategories,
-        matchKeyCategoriesByEntityId: matchKeyCategoriesByEntityId,
         styles: [],
         visibilityClass: undefined
       });


### PR DESCRIPTION
# Pull request questions

## Which issue does this address

resolves #358 

## Why was change needed

the match key filtering for core relationships was incorrect. it was essentially counting match keys from non-primary relationships between two entities that ARE related to the primary entity.. which is not correct. 

## What does change improve

fixes faulty match key filtering
