### PR TITLE
#365

### DIFF
--- a/src/lib/graph/sz-graph-filter.component.html
+++ b/src/lib/graph/sz-graph-filter.component.html
@@ -159,6 +159,14 @@
     </ul>
     </form>
   </div>
+  <!--
+  showMatchKeyTokens: {{showMatchKeyTokens}}<br/>
+  showMatchKeyTokenFilters: {{showMatchKeyTokenFilters}}<br/>
+  showMatchKeyTokenSelectAll: {{showMatchKeyTokenSelectAll}}<br/>
+  showCoreMatchKeyTokenChips: {{showCoreMatchKeyTokenChips}}<br/>
+  showExtraneousMatchKeyTokenChips: {{showExtraneousMatchKeyTokenChips}}<br/>
+  isMatchKeyTokenSelectionScopeCore: {{isMatchKeyTokenSelectionScopeCore}}
+  -->
   <div *ngIf="showMatchKeyTokens && showMatchKeyTokenFilters">
     <hr>
     <div class="filter-header match-key-token-filter-header">

--- a/src/lib/graph/sz-graph.component.ts
+++ b/src/lib/graph/sz-graph.component.ts
@@ -510,6 +510,7 @@ export class SzGraphComponent implements OnInit, OnDestroy {
   @Output() matchKeyTokensChange: EventEmitter<any> = new EventEmitter<SzMatchKeyTokenComposite[]>();
   /** event is emitted when a graph pre-flight request is performed */
   @Output() preflightRequestComplete: EventEmitter<any> = new EventEmitter<any>();
+  @Output() totalRelationshipsCountUpdated: EventEmitter<number> = new EventEmitter<number>();
 
   private getMatchKeyTokenComposites(data: SzEntityNetworkMatchKeyTokens): Array<SzMatchKeyTokenComposite> {
     let retVal: Array<SzMatchKeyTokenComposite> = [];
@@ -591,6 +592,7 @@ export class SzGraphComponent implements OnInit, OnDestroy {
       let _matchKeyTokens         = SzRelationshipNetworkComponent.getMatchKeyTokensFromEntityData(inputs.data, this.graphIds);
       let matchKeyTokens          = this.getMatchKeyTokenComposites( _matchKeyTokens );
       this.dataSourcesChange.emit( SzRelationshipNetworkComponent.getDataSourcesFromEntityNetworkData(inputs.data) );
+      this.clearMatchKeyFilters();
       this.matchKeysChange.emit( SzRelationshipNetworkComponent.getMatchKeysFromEntityNetworkData(inputs.data) )
       this.matchKeyTokensChange.emit( matchKeyTokens );
       console.log('onGraphDataLoaded: ', _matchKeyTokens, this.filterShowMatchKeyTokens, inputs);
@@ -726,6 +728,7 @@ export class SzGraphComponent implements OnInit, OnDestroy {
       this.maxEntities              = count;
       this._maxEntitiesFilterLimit  = count;
     }
+    this.totalRelationshipsCountUpdated.emit(count);
   }
 
   onDataLoaded(data) {
@@ -1076,6 +1079,21 @@ export class SzGraphComponent implements OnInit, OnDestroy {
       }
     }
   }
+  
+  /** @internal */
+  private clearMatchKeyFilters() {
+    if(this.prefs.graph) {
+      // clear out any saved match key filters
+      let _previousGraphPrefs = Object.assign({}, this.prefs.graph.toJSONObject());
+      this.prefs.graph.bulkSet = true;
+      this.prefs.graph.matchKeyCoreTokensIncluded = [];
+      this.prefs.graph.matchKeyTokensIncluded     = [];
+      this.prefs.graph.bulkSet = false;
+      this.prefs.graph.matchKeysIncluded          = [];
+      //console.warn('clearMatchKeyFilters()', _previousGraphPrefs, this.prefs.graph.toJSONObject())
+    }
+  }
+
   private isMatchKeyInEntityNode(matchKeys?, nodeData?) {
     let retVal = false;
     if(this.neverFilterQueriedEntityIds && this.graphIds.indexOf( nodeData.entityId ) >= 0){

--- a/src/lib/graph/sz-relationship-network/sz-relationship-network.component.ts
+++ b/src/lib/graph/sz-relationship-network/sz-relationship-network.component.ts
@@ -1344,8 +1344,8 @@ export class SzRelationshipNetworkComponent implements AfterViewInit, OnDestroy 
         SzFeatureMode.NONE,
         false,
         false,
-        false,
-        SzRelationshipNetworkComponent.WITH_RAW) ;
+        false, 
+        false) ;
     } else if(!this._entityIds) {
       throw new Error('entity ids are required to make "findEntityNetwork" call.');
     } else {
@@ -3443,7 +3443,7 @@ export class SzRelationshipNetworkComponent implements AfterViewInit, OnDestroy 
     let disclosedKeys = [];
     let derived_keys  = [];
     let _keyReg       = /(\+|\-)/;
-    let _keyList      = matchKey.split(_keyReg)
+    let _keyList      = matchKey && matchKey.split ? matchKey.split(_keyReg) : []
     //console.log('----- categorizeMatchKey: '+matchKey+'------', _keyList);
 
     _keyList.forEach((keyStr, _ind: number) => {

--- a/src/public-api.ts
+++ b/src/public-api.ts
@@ -69,7 +69,7 @@ export { SzEntitySearchParams } from './lib/models/entity-search';
 export { SzSearchResultEntityData } from './lib/models/responces/search-results/sz-search-result-entity-data';
 export { AdminStreamConnProperties, AdminStreamAnalysisConfig, AdminStreamLoadConfig, AdminStreamUploadRates } from './lib/models/data-admin';
 export { SzDataSourceRecordAnalysis, SzDataSourceComposite } from './lib/models/data-sources';
-export { SzGraphTooltipEntityModel, SzGraphTooltipLinkModel, SzGraphNodeFilterPair, SzMatchKeyComposite, SzMatchKeyTokenComposite, SzEntityNetworkMatchKeyTokens, SzNetworkGraphInputs } from './lib/models/graph';
+export { SzGraphTooltipEntityModel, SzGraphTooltipLinkModel, SzGraphNodeFilterPair, SzMatchKeyComposite, SzMatchKeyTokenComposite, SzEntityNetworkMatchKeyTokens, SzNetworkGraphInputs, SzMatchKeyTokenFilterScope } from './lib/models/graph';
 export { SzDataSourceRecordsSelection, SzDataSourceRecordSelection, SzWhySelectionModeBehavior, SzWhySelectionMode } from './lib/models/data-source-record-selection';
 
 /** why */


### PR DESCRIPTION
# Pull request questions

## Which issue does this address

resolves #365 

## Why was change needed

to remove persistent state from the match key token filtering.

## What does change improve

when you selected match key filters on one entity and then opened a new graph with a different entity the new entities graph would have any previously selected match key filters already active.
