### PR TITLE
match keys on graph relationship links fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 [markdownlint](https://dlaa.me/markdownlint/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [5.1.1] - 2022-08-15
+
+### Modified
+- Match keys on graph entity link(s) are now in a vertically centered multi-line list.
+- Bugfix for match key labels. (see #383)
+- Entity detail embedded graph now defaults to collapsed nodes when relationships are `< 10`
+
+relevant tickets: #309 #383
+
+
 ## [5.1.0] - 2022-07-27
 
 - there is now a new `unlimited` ui option for maximum entities allowed.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@senzing/sdk-components-ng",
-  "version": "5.1.0",
+  "version": "5.1.1",
   "scripts": {
     "ng": "ng",
     "start": "ng build @senzing/sdk-components-ng && ng serve",

--- a/src/lib/graph/sz-relationship-network/sz-relationship-network.component.scss
+++ b/src/lib/graph/sz-relationship-network/sz-relationship-network.component.scss
@@ -15,6 +15,15 @@
 
 .sz-graph-link-label {
   font-size: 10px;
+  paint-order: stroke;
+  stroke: #ffffff;
+  stroke-width: 4px;
+  stroke-linecap: butt;
+  stroke-linejoin: miter;
+  font-weight: 800;
+  fill: #565656;
+  letter-spacing: 2px;
+  line-height: 15px;
 }
 
 .sz-graph-bbox {

--- a/src/lib/scss/graph.scss
+++ b/src/lib/scss/graph.scss
@@ -65,6 +65,15 @@ body {
 
   .sz-graph-link-label {
     font-size: 10px;
+    paint-order: stroke;
+    stroke: #ffffff;
+    stroke-width: 5px;
+    stroke-linecap: square;
+    stroke-linejoin: miter;
+    font-weight: 800;
+    fill: #565656;
+    letter-spacing: 2px;
+    line-height: 15px;
   }
 
   .sz-graph-core-link {
@@ -108,7 +117,8 @@ body {
   .sz-graph-tooltip {
     position: absolute;
     background-color: white;
-    max-width: 200px;
+    min-width: 200px;
+    max-width: 50vw;
     height: auto;
     padding: 1px;
     border-radius: 4px;

--- a/src/lib/scss/styles.scss
+++ b/src/lib/scss/styles.scss
@@ -30,7 +30,9 @@ body {
     position: absolute;
     font-size: var(--sz-graph-tooltip-font-size);
     background-color: var(--sz-graph-tooltip-background-color);
+    min-width: 200px;
     max-width: var(--sz-graph-tooltip-max-width);
+    line-break: anywhere;
     height: auto;
     padding: var(--sz-graph-tooltip-padding);
     border-radius: var(--sz-graph-tooltip-border-radius);

--- a/src/lib/scss/theme.scss
+++ b/src/lib/scss/theme.scss
@@ -327,7 +327,7 @@ body {
     /* tooltip */
     --sz-graph-tooltip-font-size: 10px;
     --sz-graph-tooltip-background-color: #fff;
-    --sz-graph-tooltip-max-width: 200px;
+    --sz-graph-tooltip-max-width: 20vw;
     --sz-graph-tooltip-padding: 10px;
     --sz-graph-tooltip-border-radius: 4px;
     --sz-graph-tooltip-border: 1px solid rgb(214, 214, 214);

--- a/src/package.json
+++ b/src/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@senzing/sdk-components-ng",
-  "version": "5.1.0-beta.0",
+  "version": "5.1.1",
   "private": false,
   "keywords" :["Angular","Library","Senzing"],
   "license" : "SEE LICENSE IN LICENSE",


### PR DESCRIPTION
# Pull request questions

![image](https://user-images.githubusercontent.com/13721038/182938260-85319996-19bd-4043-9b9b-47fc6254b109.png)

## Which issue does this address

resolves #308
resolves #383 

## Why was change needed

- match keys displayed were incorrect
- match keys were hard to read.

## What does change improve

- link match key label readability
- link match key label accuracy
