### PR TITLE
Graph component optimizations and bugfixes

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,7 +10,7 @@ updates:
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     assignees:
       - "arawinters"
     allow:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,14 +6,27 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 [markdownlint](https://dlaa.me/markdownlint/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [5.1.1] - 2022-08-15
+## [5.1.1] - 2022-09-28
+
+
+### Added
+- Added "hide indirect links" UI control to graph filtering component.
+- Added `suppressL1InterLinks` to graph preferences
+- Added `linkColor` to graph preferences
+- Added `indirectLinkColor` to graph preferences
+- Added *Link Color* section to graph filter component
+- Added *Data Sources* list to graph hover tooltip
 
 ### Modified
 - Match keys on graph entity link(s) are now in a vertically centered multi-line list.
 - Bugfix for match key labels. (see #383)
 - Entity detail embedded graph now defaults to collapsed nodes when relationships are `<= 10`
+- `showMatchKeys` UI/UX parameter renamed to `showLinkLabels` to avoid confusion with `matchKeyFilters` and `showMatchKeyTokens` which are functional/behavior parameters.
+- Graph api call pattern changed to an initial entity request followed by a minimal `entity-networks` call to retrieve the necessary data. This new surface pattern dramatically decreases the time needed to initially render a graph with a large about of relationships.
+- Graph entity name label no longer clips with ellipsis.
+- Graph entity name now performs a hard word wrap to display the full name on multiple lines
 
-relevant tickets: #309 #364 #383
+relevant tickets: #309 #364 #383 #407 #413 #414 #415 #417
 
 
 ## [5.1.0] - 2022-07-27

--- a/package-lock.json
+++ b/package-lock.json
@@ -2572,9 +2572,9 @@
       }
     },
     "@senzing/rest-api-client-ng": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@senzing/rest-api-client-ng/-/rest-api-client-ng-5.0.0.tgz",
-      "integrity": "sha512-OU7xl4K3wOthsX5NbAJ5s2K2FVL4ppekGjmppFoaFMLwwZtSmysU8mYkVClUQxR/UNoQvi5oEgzpBw6q3qj/cg==",
+      "version": "5.1.0-beta.1",
+      "resolved": "https://registry.npmjs.org/@senzing/rest-api-client-ng/-/rest-api-client-ng-5.1.0-beta.1.tgz",
+      "integrity": "sha512-YBRkApBkIr55DIqQlqdY5gUoA06+Jh2Sm2oMqfCHLs4+kTWM+occPOdwEoIdH3scb1zI+c9J6gaq1cio6EZ8wg==",
       "requires": {
         "tslib": "~2.3.0"
       },

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "@angular/platform-browser": "~13.3.0",
     "@angular/platform-browser-dynamic": "~13.3.0",
     "@angular/router": "~13.3.0",
-    "@senzing/rest-api-client-ng": "^5.0.0",
+    "@senzing/rest-api-client-ng": "^5.1.0-beta.1",
     "acorn": "^8.6.0",
     "ajv": "^6.12.6",
     "d3": "^5.9.1",

--- a/src/lib/common/utils.ts
+++ b/src/lib/common/utils.ts
@@ -39,6 +39,17 @@ export function parseSzIdentifier(value: any): number {
   return retVal;
 }
 
+/** check whether a value is boolean */
+export function isBoolean(value: any) {
+  let retVal = false;
+  if(typeof value === 'boolean') {
+    retVal = true;
+  } else if(typeof value === 'string' && (value as string).toLowerCase() && ((value as string).toLocaleLowerCase() === 'true' || (value as string).toLocaleLowerCase() === 'false')) {
+    retVal = true;
+  }
+  return retVal;
+}
+
 export function nonTextTrim(value: string): string {
   let retVal = value;
   return retVal;

--- a/src/lib/configuration/sz-preferences/sz-preferences.component.spec.ts
+++ b/src/lib/configuration/sz-preferences/sz-preferences.component.spec.ts
@@ -343,9 +343,9 @@ describe('SzPreferencesComponent', () => {
       });
       fixture.componentInstance.GraphOpenInSidePanel = true;
     });
-    it('graph "showMatchKeys" changes to true', (done) => {
+    it('graph "showLinkLabels" changes to true', (done) => {
       fixture.componentInstance.prefsChange.subscribe((g: SzSdkPrefsModel) => {
-        expect(g.graph.showMatchKeys).toEqual(true);
+        expect(g.graph.showLinkLabels).toEqual(true);
         done();
       });
       fixture.componentInstance.GraphShowLinkLabels = true;

--- a/src/lib/configuration/sz-preferences/sz-preferences.component.spec.ts
+++ b/src/lib/configuration/sz-preferences/sz-preferences.component.spec.ts
@@ -348,7 +348,7 @@ describe('SzPreferencesComponent', () => {
         expect(g.graph.showMatchKeys).toEqual(true);
         done();
       });
-      fixture.componentInstance.GraphShowMatchKeys = true;
+      fixture.componentInstance.GraphShowLinkLabels = true;
     });
     it('graph "rememberStateOptions" changes to true', (done) => {
       fixture.componentInstance.prefsChange.subscribe((g: SzSdkPrefsModel) => {

--- a/src/lib/configuration/sz-preferences/sz-preferences.component.ts
+++ b/src/lib/configuration/sz-preferences/sz-preferences.component.ts
@@ -384,12 +384,12 @@ export class SzPreferencesComponent implements OnInit, OnDestroy {
     this.prefs.graph.dataSourceColors = value;
   }
   /** show match keys on relationship edges in graph */
-  public get GraphShowMatchKeys(): boolean {
-    return this.prefs.graph.showMatchKeys;
+  public get GraphShowLinkLabels(): boolean {
+    return this.prefs.graph.showLinkLabels;
   }
   /** show match keys on relationship edges in graph */
-  @Input() public set GraphShowMatchKeys(value: boolean) {
-    this.prefs.graph.showMatchKeys = value;
+  @Input() public set GraphShowLinkLabels(value: boolean) {
+    this.prefs.graph.showLinkLabels = value;
   }
   /** publish prefs change events on state change in graph component */
   public get GraphRememberStateOptions(): boolean {

--- a/src/lib/entity/detail/sz-entity-detail-graph/sz-entity-detail-graph.component.html
+++ b/src/lib/entity/detail/sz-entity-detail-graph/sz-entity-detail-graph.component.html
@@ -35,6 +35,7 @@
     [filter]="entityNodeFilters" 
     [ignoreFilters]="ignoreFilters"
     [showLinkLabels]="_showMatchKeys"
+    [suppressL1InterLinks]="_suppressL1InterLinks"
     [captureMouseWheel]="captureMouseWheel"
     (onWheelScroll)="onGraphScrollEvent($event)"
     (contextMenuClick)="onRightClick($event)"

--- a/src/lib/entity/detail/sz-entity-detail-graph/sz-entity-detail-graph.component.html
+++ b/src/lib/entity/detail/sz-entity-detail-graph/sz-entity-detail-graph.component.html
@@ -34,7 +34,7 @@
     [highlight]="entityNodeColors"
     [filter]="entityNodeFilters" 
     [ignoreFilters]="ignoreFilters"
-    [showLinkLabels]="_showMatchKeys"
+    [showLinkLabels]="_showLinkLabels"
     [suppressL1InterLinks]="_suppressL1InterLinks"
     [captureMouseWheel]="captureMouseWheel"
     (onWheelScroll)="onGraphScrollEvent($event)"
@@ -48,12 +48,12 @@
     [maxEntities]="maxEntities"></sz-relationship-network>
 
     <sz-graph-control *ngIf="showMatchKeyControl" class="sz-graph-control"
-    [showLinkLabels]="_showMatchKeys"
+    [showLinkLabels]="_showLinkLabels"
     (optionChanged)="onOptionChange($event)"
     ></sz-graph-control>
 
     <sz-graph-filter *ngIf="showFiltersControl" class="sz-graph-filter"
-    [showLinkLabels]="_showMatchKeys"
+    [showLinkLabels]="_showLinkLabels"
     (optionChanged)="onOptionChange($event)"
     ></sz-graph-filter>
     <!-- 

--- a/src/lib/entity/detail/sz-entity-detail-graph/sz-standalone-graph.component.html
+++ b/src/lib/entity/detail/sz-entity-detail-graph/sz-standalone-graph.component.html
@@ -37,6 +37,7 @@
       [includes]="entityMatchTokenFilter"
       [expandByDefaultWhenLessThan]="expandByDefaultWhenLessThan"
       [showLinkLabels]="_showMatchKeys"
+      [suppressL1InterLinks]="_suppressL1InterLinks"
       (contextMenuClick)="onRightClick($event)"
       (entityClick)="onEntityClick($event)"
       (relationshipClick)="onLinkClick($event)"
@@ -48,8 +49,7 @@
       (scaleChanged)="onGraphZoom($event)"
       [noMaxEntitiesLimit]="unlimitedMaxEntities"
       [noMaxScopeLimit]="unlimitedMaxScope"
-      [maxEntities]="maxEntities"></sz-relationship-network>
-  
+      [maxEntities]="maxEntities"></sz-relationship-network>  
     <sz-graph-control *ngIf="showMatchKeyControl" class="sz-graph-control"
       [showLinkLabels]="_showMatchKeys"
       (optionChanged)="onOptionChange($event)"
@@ -92,6 +92,10 @@
     </svg>
   </div>
   <!--
+    _showMatchKeys: {{ _showMatchKeys }}<br/>
+    _suppressL1InterLinks: {{ _suppressL1InterLinks }}<br/>
+
     filterControlPosition: "{{ filterControlPosition }}"<br/>
-    entityIds: {{ graphIds }} -->
+    entityIds: {{ graphIds }}
+  -->
 <!-- end graph container -->

--- a/src/lib/entity/detail/sz-entity-detail-graph/sz-standalone-graph.component.html
+++ b/src/lib/entity/detail/sz-entity-detail-graph/sz-standalone-graph.component.html
@@ -36,7 +36,7 @@
       [filter]="entityNodeFilters"
       [includes]="entityMatchTokenFilter"
       [expandByDefaultWhenLessThan]="expandByDefaultWhenLessThan"
-      [showLinkLabels]="_showMatchKeys"
+      [showLinkLabels]="_showLinkLabels"
       [suppressL1InterLinks]="_suppressL1InterLinks"
       (contextMenuClick)="onRightClick($event)"
       (entityClick)="onEntityClick($event)"
@@ -51,7 +51,7 @@
       [noMaxScopeLimit]="unlimitedMaxScope"
       [maxEntities]="maxEntities"></sz-relationship-network>  
     <sz-graph-control *ngIf="showMatchKeyControl" class="sz-graph-control"
-      [showLinkLabels]="_showMatchKeys"
+      [showLinkLabels]="_showLinkLabels"
       (optionChanged)="onOptionChange($event)"
     ></sz-graph-control>
   
@@ -61,7 +61,7 @@
         [class.top-right]="filterControlPosition == 'top-right'"
         [class.bottom-right]="filterControlPosition == 'bottom-right'"
         [class.bottom-left]="filterControlPosition == 'bottom-left'"
-        [showLinkLabels]="_showMatchKeys"
+        [showLinkLabels]="_showLinkLabels"
         (optionChanged)="onOptionChange($event)"
         (matchKeyTokenSelectionScopeChanged)="onFilterMatchKeyTokenSelectionScopeChanged($event)"
         [showDataSources]="filterShowDataSources"

--- a/src/lib/entity/detail/sz-entity-detail.component.html
+++ b/src/lib/entity/detail/sz-entity-detail.component.html
@@ -37,7 +37,7 @@
     [showMatchKeyControl]="graphShowMatchKeyControl"
     [showFiltersControl]="graphShowFiltersControl"
     [matchKeyTokenSelectionScope]="graphMatchKeyTokenSelectionScope"
-    [showMatchKeys]="this._showGraphMatchKeys"
+    [showLinkLabels]="this._showGraphLinkLabels"
     (contextMenuClick)="onGraphRightClick($event)"
     (relationshipContextMenuClick)="onGraphRelationshipRightClick($event)"
     (scrollWheelEvent)="graphScrollWheelEvent.emit($event)"

--- a/src/lib/entity/detail/sz-entity-detail.component.ts
+++ b/src/lib/entity/detail/sz-entity-detail.component.ts
@@ -541,13 +541,13 @@ export class SzEntityDetailComponent implements OnInit, OnDestroy, AfterViewInit
     return this._graphTitle;
   }
 
-  public _showGraphMatchKeys: boolean = true;
+  public _showGraphLinkLabels: boolean = true;
   /**
    * show or hide the "At a Glance" section.
    */
   @Input()
   public set showGraphMatchKeys(value: any) {
-    this._showGraphMatchKeys = parseBool(value);
+    this._showGraphLinkLabels = parseBool(value);
   }
   /**
    * whether or not the graph component is displaying match keys
@@ -556,7 +556,7 @@ export class SzEntityDetailComponent implements OnInit, OnDestroy, AfterViewInit
     if(this.graphComponent && this.graphComponent.graphControlComponent && this.graphComponent.graphControlComponent.showLinkLabels) {
       return this.graphComponent.graphControlComponent.showLinkLabels;
     } else {
-      return this._showGraphMatchKeys;
+      return this._showGraphLinkLabels;
     }
   }
 

--- a/src/lib/graph/sz-graph-filter.component.html
+++ b/src/lib/graph/sz-graph-filter.component.html
@@ -112,21 +112,27 @@
     </ng-container>
   </ul>
   </form>
-  <!--
-  <ul class="filters-list">
-    <ng-container *ngFor="let ds of dataSources; let i = index">
-        <ng-container *ngIf="shouldDataSourceBeDisplayed(ds.name)">
-            <li>
-              <label>
-                <input type="checkbox" [(ngModel)]="!ds.hidden" (change)="onDsFilterChange(ds.name, $event)">{{ds.name}}
-              </label>
-            </li>
-        </ng-container>
-    </ng-container>
-  </ul>
-  -->
   <hr>
   <h3>{{ sectionTitles[2] }}</h3>
+  <ul class="colors-list">
+    <li class="color-box">
+      <div class="color-box-placeholder"></div>
+      <label>
+        <input type="color" [(ngModel)]="linkColor" [style.background-color]="linkColor" (change)="onColorParameterChange('linkColor', getValueFromEventTarget($event))">
+        Directly Related
+      </label>
+    </li>
+    <li class="color-box">
+      <div class="color-box-placeholder"></div>
+      <label>
+        <input type="color" [(ngModel)]="indirectLinkColor" [style.background-color]="indirectLinkColor" (change)="onColorParameterChange('indirectLinkColor', getValueFromEventTarget($event))">
+        Indirectly Related
+      </label>
+    </li>
+  </ul>
+
+  <hr>
+  <h3>{{ sectionTitles[3] }}</h3>
   <ul cdkDropList class="colors-list" (cdkDropListDropped)="onColorOrderDrop($event)">
     <ng-container *ngFor="let ds of dataSourceColors; let i = index">
       <li class="color-box" *ngIf="shouldDataSourceBeDisplayed(ds.name)" cdkDrag [cdkDragData]="ds.name">
@@ -143,7 +149,7 @@
   </ul>
 
   <hr>
-  <h3>{{ sectionTitles[3] }}</h3>
+  <h3>{{ sectionTitles[4] }}</h3>
   <form [formGroup]="colorsMiscForm">
   <ul class="other-colors-list">
     <li>
@@ -162,7 +168,7 @@
   <div *ngIf="showMatchKeys && showMatchKeyFilters">
     <hr>
     <h3>
-      {{ sectionTitles[4] }}
+      {{ sectionTitles[5] }}
     </h3>
     <form [formGroup]="filterByMatchKeysForm">
     <ul class="filters-list">
@@ -190,7 +196,7 @@
     <hr>
     <div class="filter-header match-key-token-filter-header">
       <h3>
-        {{ sectionTitles[5] }}
+        {{ sectionTitles[6] }}
       </h3>
       <div *ngIf="showMatchKeyTokenSelectAll" class="bulk-select-options">
         [<span (click)="onSelectAllMatchKeyTokens(true)">All On</span> | <span (click)="onSelectAllMatchKeyTokens(false)">All Off</span>]

--- a/src/lib/graph/sz-graph-filter.component.html
+++ b/src/lib/graph/sz-graph-filter.component.html
@@ -4,21 +4,40 @@
   <form [formGroup]="slidersForm">
   <ul class="sliders-list">
     <li class="has-tooltip block-level-src no-text-selection">
-      <span class="tooltip">display match keys on relationship lines</span>
-      <label>
-        <!-- start graph match keys checkbox -->
-        <input type="checkbox"
-          id="sz-graph-toggle-match-keys" name="sz-graph-toggle-match-keys"
-          [checked]="showLinkLabels"
-          (change)="onCheckboxPrefToggle('showLinkLabels',$event)">
-        <!-- end graph match keys checkbox -->
-        Show Match Keys
+      <label class="checkbox-row">
+        <div class="checkbox-row">
+          <span class="has-tooltip">
+            Show Match Keys
+            <span class="tooltip tooptip-left">display match keys on relationship lines</span>
+          </span>
+          <span class="left-adjusted no-text"><mat-checkbox [checked]="showLinkLabels" (change)="onCheckboxPrefToggle('showLinkLabels',$event.checked)"></mat-checkbox></span>
+        </div>
       </label>
     </li>
-
-    <li>
-      <label style="display: block;">
-        <div style="display: flex; flex-direction: row; justify-content: space-between;">
+    <!--<li class="has-tooltip block-level-src no-text-selection">
+      <span class="tooltip">do not show inter-related first level links</span>
+      <label>
+        <input type="checkbox"
+          id="sz-graph-toggle-l1-link" name="sz-graph-toggle-l1-links"
+          [checked]="suppressL1InterLinks"
+          (change)="onCheckboxPrefToggle('suppressL1InterLinks',$event)">
+        Suppress Indirect Links
+      </label>
+    </li>-->
+    <li class="has-tooltip block-level-src no-text-selection">
+      <label class="checkbox-row">
+        <div class="checkbox-row">
+          <span class="has-tooltip">
+            Suppress Indirect Links
+            <span class="tooltip tooptip-left">do not show inter-related first level links</span>
+          </span>
+          <span class="left-adjusted no-text"><mat-checkbox [checked]="suppressL1InterLinks" (change)="onCheckboxPrefToggle('suppressL1InterLinks',$event.checked)"></mat-checkbox></span>
+        </div>
+      </label>
+    </li>
+    <li class="has-tooltip block-level-src no-text-selection">
+      <label class="checkbox-row">
+        <div class="checkbox-row">
           <span class="has-tooltip">
             Scope
             <span class="tooltip tooptip-left">number of relationship hops away from focused entity</span>
@@ -26,7 +45,7 @@
           <span class="left-adjusted"><mat-checkbox [checked]="unlimitedMaxScope" (change)="onMaxUnlimitedChange('unlimitedMaxScope',$event.checked)">unlimited</mat-checkbox></span>
         </div>
       </label>
-      <label *ngIf="!unlimitedMaxScope" style="display: flex; flex-direction: row; justify-content: space-between; align-content: center; flex-wrap: nowrap; align-items: center;">
+      <label class="slider-row" *ngIf="!unlimitedMaxScope">
         <mat-slider style="width: 100%" min="1" [max]="buildOutMax" 
         [disabled]="unlimitedMaxScope" 
         [value]="buildOut"
@@ -37,9 +56,9 @@
         <span class="intVal">({{ buildOut }})</span>
       </label>
     </li>
-    <li *ngIf="showMaxEntities">
-      <label style="display: block;">
-        <div style="display: flex; flex-direction: row; justify-content: space-between;">
+    <li class="has-tooltip block-level-src no-text-selection" *ngIf="showMaxEntities">
+      <label class="checkbox-row">
+        <div class="checkbox-row">
           <span class="has-tooltip">
             Max
             <span class="tooltip tooptip-left">hard limit on how many entities will be displayed</span>
@@ -47,7 +66,7 @@
           <span class="left-adjusted"><mat-checkbox [checked]="unlimitedMaxEntities" (change)="onMaxUnlimitedChange('unlimitedMaxEntities',$event.checked)">unlimited</mat-checkbox></span>
         </div>
       </label>
-      <label *ngIf="!unlimitedMaxEntities" style="display: flex; flex-direction: row; justify-content: space-between; align-content: center; flex-wrap: nowrap; align-items: center;">
+      <label class="slider-row" *ngIf="!unlimitedMaxEntities" style="display: flex; flex-direction: row; justify-content: space-between; align-content: center; flex-wrap: nowrap; align-items: center;">
         <mat-slider style="width: 100%" min="1" [max]="maxEntitiesLimit + 3" step="3" 
         [disabled]="unlimitedMaxEntities" 
         [value]="maxEntities"

--- a/src/lib/graph/sz-graph-filter.component.html
+++ b/src/lib/graph/sz-graph-filter.component.html
@@ -28,7 +28,7 @@
       <label class="checkbox-row">
         <div class="checkbox-row">
           <span class="has-tooltip">
-            Suppress Indirect Links
+            Hide Indirect Links
             <span class="tooltip tooptip-left">do not show inter-related first level links</span>
           </span>
           <span class="left-adjusted no-text"><mat-checkbox [checked]="suppressL1InterLinks" (change)="onCheckboxPrefToggle('suppressL1InterLinks',$event.checked)"></mat-checkbox></span>

--- a/src/lib/graph/sz-graph-filter.component.scss
+++ b/src/lib/graph/sz-graph-filter.component.scss
@@ -12,27 +12,53 @@
     list-style-type: none;
     margin: 0;
     padding: 0;
-  }
 
-  li {
-    margin: var(--sz-entity-graph-control-item-margin);
-    display: block;
-    background-color: var(--sz-entity-graph-control-item-background-color);
-    padding: 4px 1em 4px 1em;
-    cursor: var(--sz-entity-graph-control-cursor);
-
-    /*
-    &:hover {
-      cursor: var(--sz-entity-graph-control-item-cursor);
-    }*/
-
-    label {
-      cursor: var(--sz-entity-graph-control-item-cursor);
-    }
-    a {
+    li {
+      margin: var(--sz-entity-graph-control-item-margin);
       display: block;
-      cursor: var(--sz-entity-graph-control-item-cursor);
+      background-color: var(--sz-entity-graph-control-item-background-color);
+      padding: 4px 1em 4px 1em;
+      cursor: var(--sz-entity-graph-control-cursor);
+  
+      /*
+      &:hover {
+        cursor: var(--sz-entity-graph-control-item-cursor);
+      }*/
+  
+      label {
+        cursor: var(--sz-entity-graph-control-item-cursor);
+      }
+      a {
+        display: block;
+        cursor: var(--sz-entity-graph-control-item-cursor);
+      }
     }
+    &.sliders-list {
+      label.slider-row {
+        display: flex; 
+        flex-direction: row; 
+        justify-content: space-between; 
+        align-content: center; 
+        flex-wrap: nowrap; 
+        align-items: center;
+      }
+
+      label.checkbox-row {
+        display: block;
+        .checkbox-row {
+          display: flex; 
+          flex-direction: row; 
+          justify-content: space-between;
+
+          .left-adjusted {
+            &.no-text {
+              min-width: 77px;
+            }
+          }
+        }
+      }
+    }
+
   }
 
   h3:first-child {

--- a/src/lib/graph/sz-graph-filter.component.scss
+++ b/src/lib/graph/sz-graph-filter.component.scss
@@ -124,7 +124,7 @@
       position: relative;
       flex-direction: row;
       align-items: center;
-      justify-content: space-between;
+      /*justify-content: space-between;*/
       box-sizing: border-box;
     }
     .color-box-handle {

--- a/src/lib/graph/sz-graph-filter.component.ts
+++ b/src/lib/graph/sz-graph-filter.component.ts
@@ -8,6 +8,7 @@ import { CdkDragDrop, moveItemInArray } from '@angular/cdk/drag-drop';
 import { SzDataSourceComposite } from '../models/data-sources';
 import { SzMatchKeyComposite, SzMatchKeyTokenComposite, SzEntityNetworkMatchKeyTokens, SzMatchKeyTokenFilterScope } from '../models/graph';
 import { sortDataSourcesByIndex, parseBool, sortMatchKeysByIndex, sortMatchKeyTokensByIndex } from '../common/utils';
+import { isBoolean } from '../common/utils';
 
 /**
  * Control Component allowing UI friendly changes
@@ -275,6 +276,15 @@ export class SzGraphFilterComponent implements OnInit, AfterViewInit, OnDestroy 
   public get showLinkLabels(): boolean {
     return this._showLinkLabels;
   }
+  /** show match keys */
+  public _suppressL1InterLinks = true;
+  @Input() public set suppressL1InterLinks(value){
+    this._suppressL1InterLinks = value;
+  }
+  public get suppressL1InterLinks(): boolean {
+    return this._suppressL1InterLinks;
+  }
+
   /** titles that are displayed for each section in component */
   @Input() sectionTitles = [
     'Filters',
@@ -290,6 +300,12 @@ export class SzGraphFilterComponent implements OnInit, AfterViewInit, OnDestroy 
   }
   @HostBinding('class.not-showing-link-labels') public get hidingLinkLabels(): boolean {
     return !this._showLinkLabels;
+  }
+  @HostBinding('class.showing-inter-link-lines') public get showingInterLinkLines(): boolean {
+    return !this._suppressL1InterLinks;
+  }
+  @HostBinding('class.not-showing-inter-link-lines') public get hidingInterLinkLines(): boolean {
+    return this._suppressL1InterLinks;
   }
 
   // ------------------------------------  getters and setters --------------------------
@@ -506,8 +522,10 @@ export class SzGraphFilterComponent implements OnInit, AfterViewInit, OnDestroy 
       _checked = event.target.checked;
     } else if (event.srcElement) {
       _checked = event.srcElement.checked;
+    } else if (isBoolean(event)) {
+      _checked = (event as boolean);
     }
-    //console.log('@senzing/sdk-components-ng/SzEntityDetailGraphFilterComponent.onCheckboxPrefToggle: ', _checked, optName, event);
+    console.log('@senzing/sdk-components-ng/SzEntityDetailGraphFilterComponent.onCheckboxPrefToggle: ', optName, _checked, event);
     this.optionChanged.emit({'name': optName, value: _checked});
   }
   /** when the user selects either the scope or entity limit "unlimited" checkboxes
@@ -522,16 +540,17 @@ export class SzGraphFilterComponent implements OnInit, AfterViewInit, OnDestroy 
 
   /** proxy handler for when prefs have changed externally */
   private onPrefsChange(prefs: any) {
-    this._showLinkLabels = prefs.showMatchKeys;
+    this._showLinkLabels        = prefs.showMatchKeys;
+    this._suppressL1InterLinks  = prefs.suppressL1InterLinks
     this.maxDegreesOfSeparation = prefs.maxDegreesOfSeparation;
-    this.maxEntities = prefs.maxEntities;
-    this.buildOut = prefs.buildOut;
-    this.dataSourceColors = prefs.dataSourceColors;
-    this.dataSourcesFiltered = prefs.dataSourcesFiltered;
-    this.matchKeysIncluded = prefs.matchKeysIncluded;
+    this.maxEntities            = prefs.maxEntities;
+    this.buildOut               = prefs.buildOut;
+    this.dataSourceColors       = prefs.dataSourceColors;
+    this.dataSourcesFiltered    = prefs.dataSourcesFiltered;
+    this.matchKeysIncluded      = prefs.matchKeysIncluded;
     this.matchKeyTokensIncluded = prefs.matchKeyTokensIncluded;
     this.matchKeyCoreTokensIncluded = prefs.matchKeyCoreTokensIncluded;
-    this.queriedEntitiesColor = prefs.queriedEntitiesColor;
+    this.queriedEntitiesColor   = prefs.queriedEntitiesColor;
     //console.log('@senzing/sdk-components-ng/sz-entity-detail-graph-filter.onPrefsChange(): ', prefs, this.dataSourceColors);
     // update view manually (for web components redraw reliability)
     this.cd.detectChanges();

--- a/src/lib/graph/sz-graph-filter.component.ts
+++ b/src/lib/graph/sz-graph-filter.component.ts
@@ -558,7 +558,7 @@ export class SzGraphFilterComponent implements OnInit, AfterViewInit, OnDestroy 
     this.queriedEntitiesColor   = prefs.queriedEntitiesColor;
     this.linkColor              = prefs.linkColor;
     this.indirectLinkColor      = prefs.indirectLinkColor;
-    console.log('@senzing/sdk-components-ng/sz-entity-detail-graph-filter.onPrefsChange(): ', prefs, this.dataSourceColors);
+    //console.log('@senzing/sdk-components-ng/sz-entity-detail-graph-filter.onPrefsChange(): ', prefs, this.dataSourceColors);
     // update view manually (for web components redraw reliability)
     this.cd.detectChanges();
   }

--- a/src/lib/graph/sz-graph-filter.component.ts
+++ b/src/lib/graph/sz-graph-filter.component.ts
@@ -211,6 +211,8 @@ export class SzGraphFilterComponent implements OnInit, AfterViewInit, OnDestroy 
   @Input() matchKeyTokensIncluded: string[]     = [];
   @Input() matchKeyCoreTokensIncluded: string[] = [];
   @Input() queriedEntitiesColor: string;
+  @Input() linkColor: string;
+  @Input() indirectLinkColor: string;
 
   /** 
    * set the internal list of datasource colors from local storage or input value
@@ -289,8 +291,9 @@ export class SzGraphFilterComponent implements OnInit, AfterViewInit, OnDestroy 
   @Input() sectionTitles = [
     'Filters',
     'Filter by Source',
+    'Link Colors',
     'Colors by Source',
-    'Color by: ',
+    'Focused Entity: ',
     'Filter by Match Key',
     'Filter by Match Key'
   ];
@@ -511,6 +514,7 @@ export class SzGraphFilterComponent implements OnInit, AfterViewInit, OnDestroy 
   }
   /** handler for when an string color pref value has changed. ie: queriedEntitiesColor  */
   onColorParameterChange(prefName, value) {
+    console.log('onColorParameterChange: ', prefName, value, this.prefs.graph.suppressL1InterLinks);
     try {
       this.prefs.graph[prefName] = value;
     } catch(err) {}
@@ -526,6 +530,7 @@ export class SzGraphFilterComponent implements OnInit, AfterViewInit, OnDestroy 
       _checked = (event as boolean);
     }
     console.log('@senzing/sdk-components-ng/SzEntityDetailGraphFilterComponent.onCheckboxPrefToggle: ', optName, _checked, event);
+    this.prefs.graph[optName] = parseBool(_checked);
     this.optionChanged.emit({'name': optName, value: _checked});
   }
   /** when the user selects either the scope or entity limit "unlimited" checkboxes
@@ -551,7 +556,9 @@ export class SzGraphFilterComponent implements OnInit, AfterViewInit, OnDestroy 
     this.matchKeyTokensIncluded = prefs.matchKeyTokensIncluded;
     this.matchKeyCoreTokensIncluded = prefs.matchKeyCoreTokensIncluded;
     this.queriedEntitiesColor   = prefs.queriedEntitiesColor;
-    //console.log('@senzing/sdk-components-ng/sz-entity-detail-graph-filter.onPrefsChange(): ', prefs, this.dataSourceColors);
+    this.linkColor              = prefs.linkColor;
+    this.indirectLinkColor      = prefs.indirectLinkColor;
+    console.log('@senzing/sdk-components-ng/sz-entity-detail-graph-filter.onPrefsChange(): ', prefs, this.dataSourceColors);
     // update view manually (for web components redraw reliability)
     this.cd.detectChanges();
   }
@@ -665,7 +672,7 @@ export class SzGraphFilterComponent implements OnInit, AfterViewInit, OnDestroy 
    * the the public "matchKeyTokenSelectionScopeChanged" event emitter.
    */
   private onMatchKeyTokenSelectionScopeChanged(scope: SzMatchKeyTokenFilterScope) {
-    //console.log('onMatchKeyTokenSelectionScopeChanged: ', scope);
+    console.log('onMatchKeyTokenSelectionScopeChanged: ', scope);
     
     // now emit events
     this.optionChanged.emit({name: 'matchKeyTokenFilterScope', value: scope});

--- a/src/lib/graph/sz-graph.component.html
+++ b/src/lib/graph/sz-graph.component.html
@@ -21,7 +21,7 @@
       [filter]="entityNodeFilters"
       [includes]="entityMatchTokenFilter"
       [expandByDefaultWhenLessThan]="expandByDefaultWhenLessThan"
-      [showLinkLabels]="_showMatchKeys"
+      [showLinkLabels]="_showLinkLabels"
       [suppressL1InterLinks]="_suppressL1InterLinks"
       (contextMenuClick)="onRightClick($event)"
       (entityClick)="onEntityClick($event)"
@@ -34,7 +34,7 @@
       [maxEntities]="maxEntities"></sz-relationship-network>
   
       <sz-graph-control *ngIf="showMatchKeyControl" class="sz-graph-control"
-      [showLinkLabels]="_showMatchKeys"
+      [showLinkLabels]="_showLinkLabels"
       (optionChanged)="onOptionChange($event)"
       ></sz-graph-control>
   
@@ -44,7 +44,7 @@
         [class.top-right]="filterControlPosition == 'top-right'"
         [class.bottom-right]="filterControlPosition == 'bottom-right'"
         [class.bottom-left]="filterControlPosition == 'bottom-left'"
-        [showLinkLabels]="_showMatchKeys"
+        [showLinkLabels]="_showLinkLabels"
         (optionChanged)="onOptionChange($event)"
         [showDataSources]="filterShowDataSources"
         [showMatchKeys]="filterShowMatchKeys"

--- a/src/lib/graph/sz-graph.component.html
+++ b/src/lib/graph/sz-graph.component.html
@@ -22,6 +22,7 @@
       [includes]="entityMatchTokenFilter"
       [expandByDefaultWhenLessThan]="expandByDefaultWhenLessThan"
       [showLinkLabels]="_showMatchKeys"
+      [suppressL1InterLinks]="_suppressL1InterLinks"
       (contextMenuClick)="onRightClick($event)"
       (entityClick)="onEntityClick($event)"
       (relationshipClick)="onLinkClick($event)"

--- a/src/lib/graph/sz-graph.component.ts
+++ b/src/lib/graph/sz-graph.component.ts
@@ -427,7 +427,7 @@ export class SzGraphComponent implements OnInit, OnDestroy {
   }
   
 
-  @ViewChild('graphContainer') graphContainerEle: ElementRef;
+  @ViewChild('graphContainer') graphContainerEle: ElementRef<HTMLDivElement>;
   @ViewChild(SzGraphControlComponent) graphControlComponent: SzGraphControlComponent;
   @ViewChild(SzRelationshipNetworkComponent) graph : SzRelationshipNetworkComponent;
 

--- a/src/lib/graph/sz-graph.component.ts
+++ b/src/lib/graph/sz-graph.component.ts
@@ -89,6 +89,12 @@ export class SzGraphComponent implements OnInit, OnDestroy {
     this._showMatchKeys = parseBool(value);
   };
   /** @internal */
+  public _suppressL1InterLinks = false;
+  /** sets the visibility of edge labels on the node links */
+  @Input() public set suppressL1InterLinks(value: boolean | string) {
+    this._suppressL1InterLinks = parseBool(value);
+  };
+  /** @internal */
   private _openInNewTab: boolean = false;
   /** whether or not to open entity clicks in new tab */
   @Input() public set openInNewTab(value: boolean) {
@@ -413,6 +419,13 @@ export class SzGraphComponent implements OnInit, OnDestroy {
   @HostBinding('class.not-showing-link-labels') public get hidingLinkLabels(): boolean {
     return !this._showMatchKeys;
   }
+  @HostBinding('class.showing-inter-link-lines') public get showingInterLinkLines(): boolean {
+    return !this._suppressL1InterLinks;
+  }
+  @HostBinding('class.not-showing-inter-link-lines') public get hidingInterLinkLines(): boolean {
+    return this._suppressL1InterLinks;
+  }
+  
 
   @ViewChild('graphContainer') graphContainerEle: ElementRef;
   @ViewChild(SzGraphControlComponent) graphControlComponent: SzGraphControlComponent;
@@ -709,10 +722,13 @@ export class SzGraphComponent implements OnInit, OnDestroy {
   }
 
   public onOptionChange(event: {name: string, value: any}) {
-    //console.log('onOptionChange: ', event);
+    console.log('onOptionChange: ', event);
     switch(event.name) {
       case 'showLinkLabels':
         this.showMatchKeys = event.value;
+        break;
+      case 'suppressL1InterLinks':
+        this.suppressL1InterLinks = event.value;
         break;
     }
   }
@@ -913,6 +929,7 @@ export class SzGraphComponent implements OnInit, OnDestroy {
     if(!prefs.unlimitedMaxScope) {
       this.buildOut                   = prefs.buildOut;
     }
+    this._suppressL1InterLinks         = prefs.suppressL1InterLinks;
     this.unlimitedMaxEntities         = prefs.unlimitedMaxEntities;
     this.unlimitedMaxScope            = prefs.unlimitedMaxScope;
     this.dataSourceColors             = prefs.dataSourceColors;

--- a/src/lib/graph/sz-graph.component.ts
+++ b/src/lib/graph/sz-graph.component.ts
@@ -83,10 +83,10 @@ export class SzGraphComponent implements OnInit, OnDestroy {
     relatedEntities: SzRelatedEntity[]
   }*/
   /** @internal */
-  public _showMatchKeys = false;
+  public _showLinkLabels = false;
   /** sets the visibility of edge labels on the node links */
-  @Input() public set showMatchKeys(value: boolean | string) {
-    this._showMatchKeys = parseBool(value);
+  @Input() public set showLinkLabels(value: boolean | string) {
+    this._showLinkLabels = parseBool(value);
   };
   /** @internal */
   public _suppressL1InterLinks = false;
@@ -414,10 +414,10 @@ export class SzGraphComponent implements OnInit, OnDestroy {
     this._graphZoom = value;
   }
   @HostBinding('class.showing-link-labels') public get showingLinkLabels(): boolean {
-    return this._showMatchKeys;
+    return this._showLinkLabels;
   }
   @HostBinding('class.not-showing-link-labels') public get hidingLinkLabels(): boolean {
-    return !this._showMatchKeys;
+    return !this._showLinkLabels;
   }
   @HostBinding('class.showing-inter-link-lines') public get showingInterLinkLines(): boolean {
     return !this._suppressL1InterLinks;
@@ -725,7 +725,7 @@ export class SzGraphComponent implements OnInit, OnDestroy {
     console.log('onOptionChange: ', event);
     switch(event.name) {
       case 'showLinkLabels':
-        this.showMatchKeys = event.value;
+        this.showLinkLabels = event.value;
         break;
       case 'suppressL1InterLinks':
         this.suppressL1InterLinks = event.value;
@@ -921,15 +921,29 @@ export class SzGraphComponent implements OnInit, OnDestroy {
       prefs.unlimitedMaxEntities
       );*/
     }
-    this._showMatchKeys               = prefs.showMatchKeys;
+    this.showLinkLabels               = prefs.showLinkLabels;
     this.maxDegrees                   = prefs.maxDegreesOfSeparation;
+
+    // if we have "color" UI prefs add them here
+    if(this.graphContainerEle && this.graphContainerEle.nativeElement){
+      if(prefs.linkColor) {
+        this.graphContainerEle.nativeElement.style.setProperty('--sz-graph-link-line-color', prefs.linkColor);
+      }
+      if(prefs.indirectLinkColor) {
+        this.graphContainerEle.nativeElement.style.setProperty('--sz-graph-link-line-non-focused-color', prefs.indirectLinkColor);
+      }
+      if(prefs.queriedEntitiesColor) {
+        this.graphContainerEle.nativeElement.style.setProperty('--sz-graph-focused-entity-color', prefs.queriedEntitiesColor);
+      }
+    }
+
     if(!prefs.unlimitedMaxEntities) {
       this.maxEntities                = prefs.maxEntities;
     }
     if(!prefs.unlimitedMaxScope) {
       this.buildOut                   = prefs.buildOut;
     }
-    this._suppressL1InterLinks         = prefs.suppressL1InterLinks;
+    this._suppressL1InterLinks        = prefs.suppressL1InterLinks;
     this.unlimitedMaxEntities         = prefs.unlimitedMaxEntities;
     this.unlimitedMaxScope            = prefs.unlimitedMaxScope;
     this.dataSourceColors             = prefs.dataSourceColors;

--- a/src/lib/graph/sz-graph.component.ts
+++ b/src/lib/graph/sz-graph.component.ts
@@ -889,7 +889,7 @@ export class SzGraphComponent implements OnInit, OnDestroy {
 
   /** proxy handler for when prefs have changed externally */
   private onPrefsChange(prefs: SzGraphPrefs) {
-    console.log('@senzing/sdk-components-ng/sz-graph-component.onPrefsChange(): ', prefs, this.prefs.graph.toJSONObject());
+    //console.log('@senzing/sdk-components-ng/sz-graph-component.onPrefsChange(): ', prefs, this.prefs.graph.toJSONObject());
     let queryParamChanged = false;
     let _oldQueryParams = {maxDegrees: this.maxDegrees, maxEntities: this.maxEntities, buildOut: this.buildOut, unlimitedMaxEntities: this.unlimitedMaxEntities, unlimitedMaxScope: this.unlimitedMaxScope};
     let _newQueryParams = {maxDegrees: prefs.maxDegreesOfSeparation, maxEntities: prefs.maxEntities, buildOut: prefs.buildOut, unlimitedMaxEntities: prefs.unlimitedMaxEntities, unlimitedMaxScope: prefs.unlimitedMaxScope};
@@ -969,7 +969,7 @@ export class SzGraphComponent implements OnInit, OnDestroy {
         //console.log('prefs changed but none of them require re-query.', _oldQueryParams, _newQueryParams, queryParamChanged);
       }
     } else {
-      console.log('prefs changed but no requery', _oldQueryParams, _newQueryParams, queryParamChanged, this._graphComponentRendered);
+      //console.log('prefs changed but no requery', _oldQueryParams, _newQueryParams, queryParamChanged, this._graphComponentRendered);
     }
 
     // update view manually (for web components redraw reliability)

--- a/src/lib/graph/sz-relationship-network/sz-relationship-network.component.scss
+++ b/src/lib/graph/sz-relationship-network/sz-relationship-network.component.scss
@@ -9,9 +9,9 @@
   }
   &.not-showing-inter-link-lines {
     ::ng-deep svg.graph-chart {
-      .sz-graph-link {
-        stroke: #999;
-        &.not-primary {
+      .sz-graph-link, .sz-graph-link-label {
+        &.not-touching-focal {
+          display: none !important;
           opacity: .2;
           stroke: rgb(98, 81, 112);
         }

--- a/src/lib/graph/sz-relationship-network/sz-relationship-network.component.scss
+++ b/src/lib/graph/sz-relationship-network/sz-relationship-network.component.scss
@@ -7,6 +7,17 @@
       }
     }
   }
+  &.not-showing-inter-link-lines {
+    ::ng-deep svg.graph-chart {
+      .sz-graph-link {
+        stroke: #999;
+        &.not-primary {
+          opacity: .2;
+          stroke: rgb(98, 81, 112);
+        }
+      }
+    }
+  }
 }
 
 .sz-graph-node {

--- a/src/lib/graph/sz-relationship-network/sz-relationship-network.component.ts
+++ b/src/lib/graph/sz-relationship-network/sz-relationship-network.component.ts
@@ -349,9 +349,10 @@ export class SzRelationshipNetworkComponent implements AfterViewInit, OnDestroy 
       //console.log(`entityIds = ${value}(number[])`, value, value.toString().split(','), ((value as unknown as string[]) && (value as unknown as string[]).map));
     }
     // copy over new entity id's to "focalEntities"
-    this._focalEntities = this._focalEntities.concat(this._entityIds.filter((eId) => {
+    let uniqueEntityIds = this._entityIds && this._entityIds.filter ? this._entityIds.filter((eId) => {
       return this._focalEntities.indexOf(eId) <= -1;
-    }))
+    }) : [];
+    this._focalEntities = this._focalEntities.concat(uniqueEntityIds);
     if(this.reloadOnIdChange && this._entityIds && this._entityIds.some( (eId) => { return _oldIds && _oldIds.indexOf(eId) < 0; })) {
       this.reload( this._entityIds.map((eId) => { return parseInt(eId); }) );
     }

--- a/src/lib/graph/sz-relationship-network/sz-relationship-network.component.ts
+++ b/src/lib/graph/sz-relationship-network/sz-relationship-network.component.ts
@@ -1479,11 +1479,11 @@ export class SzRelationshipNetworkComponent implements AfterViewInit, OnDestroy 
       maxDegrees,
       1,
       maxEntities,
-      SzDetailLevel.SUMMARY,
+      SzDetailLevel.NETWORKMINIMAL,
       SzFeatureMode.NONE,
       false,
       false,
-      'network', 
+      false, 
       SzRelationshipNetworkComponent.WITHOUT_RAW
     ).pipe(
       tap(() => {
@@ -1574,7 +1574,7 @@ export class SzRelationshipNetworkComponent implements AfterViewInit, OnDestroy 
         maxDegrees,
         buildOut,
         maxEntities,
-        SzDetailLevel.SUMMARY,
+        SzDetailLevel.NETWORKMINIMAL,
         SzFeatureMode.NONE,
         false,
         false,
@@ -2842,6 +2842,19 @@ export class SzRelationshipNetworkComponent implements AfterViewInit, OnDestroy 
     }
     if(d.phone && d.phone !== null) {
       retVal += "<br/><strong>Phone</strong>: " + d.phone;
+    }
+    if(d.dataSources && d.dataSources.forEach && d.dataSources.length > 0) {
+      let dsNamesCeil = 10;
+      retVal += "<br/><strong>Data Sources</strong>: <ul>";
+      d.dataSources.forEach((dsName, dsNameInc) => {
+        if(dsNameInc <= dsNamesCeil){
+          retVal += "<li><strong>"+ dsName +"</li>";
+        }
+      });
+      retVal += "</ul>";
+      if(d.dataSources.length > dsNamesCeil) {
+        retVal += `+${d.dataSources.length - dsNamesCeil} more..`;
+      }
     }
     /*
     if(d.relationshipMatchKeys) {

--- a/src/lib/scss/graph.scss
+++ b/src/lib/scss/graph.scss
@@ -75,7 +75,7 @@ body {
     letter-spacing: 2px;
     line-height: 15px;
     &.not-touching-focal {
-      opacity: .5;
+      opacity: var(--sz-graph-link-label-non-focused-opacity);
     }
     /*
     &.related-touching-focal {

--- a/src/lib/scss/graph.scss
+++ b/src/lib/scss/graph.scss
@@ -74,6 +74,16 @@ body {
     fill: #565656;
     letter-spacing: 2px;
     line-height: 15px;
+    &.not-touching-focal {
+      opacity: .5;
+    }
+    /*
+    &.related-touching-focal {
+      stroke: rgb(187, 95, 175);
+    }
+    &.touching-focal {
+      stroke: rgb(156, 187, 95);
+    }*/
   }
 
   .sz-graph-core-link {
@@ -82,8 +92,16 @@ body {
   }
 
   .sz-graph-link {
-    stroke: #999;
+    /*stroke: #999;*/
+    stroke: var(--sz-graph-link-line-color);
     stroke-width: 1px;
+    &.not-touching-focal {
+      opacity: var(--sz-graph-link-line-non-focused-opacity);
+      stroke: var(--sz-graph-link-line-non-focused-color);
+    }
+    /*&.touching-focal {
+      stroke: rgb(156, 187, 95);
+    }*/
   }
 
   .sz-graph-node-icon {

--- a/src/lib/scss/theme.scss
+++ b/src/lib/scss/theme.scss
@@ -307,7 +307,8 @@ body {
     /* graph */
     --sz-graph-link-line-color: #999;
     --sz-graph-link-line-non-focused-color: var(--sz-graph-link-line-color);
-    --sz-graph-link-line-non-focused-opacity: .3;
+    --sz-graph-link-line-non-focused-opacity: 1;
+    --sz-graph-link-label-non-focused-opacity: 1;
 
     --sz-entity-graph-primary-entity-default-color: #465BA8;
     --sz-entity-graph-control-border: 1px solid #d3d3d3;

--- a/src/lib/scss/theme.scss
+++ b/src/lib/scss/theme.scss
@@ -305,6 +305,10 @@ body {
     /* end relationship section list vars */
 
     /* graph */
+    --sz-graph-link-line-color: #999;
+    --sz-graph-link-line-non-focused-color: var(--sz-graph-link-line-color);
+    --sz-graph-link-line-non-focused-opacity: .3;
+
     --sz-entity-graph-primary-entity-default-color: #465BA8;
     --sz-entity-graph-control-border: 1px solid #d3d3d3;
     --sz-entity-graph-control-position: absolute;

--- a/src/lib/services/sz-prefs.service.spec.ts
+++ b/src/lib/services/sz-prefs.service.spec.ts
@@ -458,14 +458,14 @@ describe('SzPrefsService', () => {
     });
     service.graph.openInSidePanel = true;
   });
-  it('graph "showMatchKeys" changes to true', (done) => {
+  it('graph "showLinkLabels" changes to true', (done) => {
     service.prefsChanged.pipe(
       debounceTime(500)
     ).subscribe((g: SzSdkPrefsModel) => {
       expect(g.graph.showMatchKeys).toEqual(true);
       done();
     });
-    service.graph.showMatchKeys = true;
+    service.graph.showLinkLabels = true;
   });
   it('graph "rememberStateOptions" changes to true', (done) => {
     service.prefsChanged.pipe(
@@ -474,7 +474,7 @@ describe('SzPrefsService', () => {
       expect(g.graph.rememberStateOptions).toEqual(true);
       done();
     });
-    service.graph.showMatchKeys = true;
+    service.graph.rememberStateOptions = true;
   });
   it('graph "maxDegreesOfSeparation" changes to 9', (done) => {
     service.prefsChanged.pipe(

--- a/src/lib/services/sz-prefs.service.spec.ts
+++ b/src/lib/services/sz-prefs.service.spec.ts
@@ -462,7 +462,7 @@ describe('SzPrefsService', () => {
     service.prefsChanged.pipe(
       debounceTime(500)
     ).subscribe((g: SzSdkPrefsModel) => {
-      expect(g.graph.showMatchKeys).toEqual(true);
+      expect(g.graph.showLinkLabels).toEqual(true);
       done();
     });
     service.graph.showLinkLabels = true;

--- a/src/lib/services/sz-prefs.service.ts
+++ b/src/lib/services/sz-prefs.service.ts
@@ -856,7 +856,7 @@ export class SzGraphPrefs extends SzSdkPrefsBase {
   /** @internal */
   private _dataSourceColors: SzDataSourceComposite[] = [];
   /** @internal */
-  private _showMatchKeys: boolean = false;
+  private _showLinkLabels: boolean = false;
   /** @internal */
   private _rememberStateOptions: boolean = true;
   /** @internal */
@@ -880,6 +880,10 @@ export class SzGraphPrefs extends SzSdkPrefsBase {
   /** @internal */
   private _queriedEntitiesColor: string | undefined = "#465BA8";
   /** @internal */
+  private _linkColor: string | undefined = "#999";
+  /** @internal */
+  private _indirectLinkColor: string | undefined = "#999";
+  /** @internal */
   private _unlimitedMaxEntities: boolean = true;
   /** @internal */
   private _unlimitedMaxScope: boolean = false;
@@ -893,7 +897,7 @@ export class SzGraphPrefs extends SzSdkPrefsBase {
     'openInNewTab',
     'openInSidePanel',
     'dataSourceColors',
-    'showMatchKeys',
+    'showLinkLabels',
     'rememberStateOptions',
     'maxDegreesOfSeparation',
     'maxEntities',
@@ -904,6 +908,8 @@ export class SzGraphPrefs extends SzSdkPrefsBase {
     'matchKeyCoreTokensIncluded',
     'neverFilterQueriedEntityIds',
     'queriedEntitiesColor',
+    'linkColor',
+    'indirectLinkColor',
     'unlimitedMaxEntities',
     'unlimitedMaxScope',
     'suppressL1InterLinks'
@@ -938,12 +944,12 @@ export class SzGraphPrefs extends SzSdkPrefsBase {
     if(!this.bulkSet && this._rememberStateOptions) this.prefsChanged.next( this.toJSONObject() );
   }
   /** show match keys/edge labels on relationships */
-  public get showMatchKeys(): boolean {
-    return this._showMatchKeys;
+  public get showLinkLabels(): boolean {
+    return this._showLinkLabels;
   }
   /** show match keys/edge labels on relationships */
-  public set showMatchKeys(value: boolean) {
-    this._showMatchKeys = value;
+  public set showLinkLabels(value: boolean) {
+    this._showLinkLabels = value;
     if(!this.bulkSet && this._rememberStateOptions) this.prefsChanged.next( this.toJSONObject() );
   }
   /** whether or not to publish change events on property value changes.
@@ -1039,6 +1045,24 @@ export class SzGraphPrefs extends SzSdkPrefsBase {
   /** color of active or queried for entity or entitities */
   public set queriedEntitiesColor(value: string | undefined) {
     this._queriedEntitiesColor = value;
+    if(!this.bulkSet) this.prefsChanged.next( this.toJSONObject() );
+  }
+  /** color of link lines */
+  public get linkColor(): string | undefined {
+    return this._linkColor;
+  }
+  /** color of link lines */
+  public set linkColor(value: string | undefined) {
+    this._linkColor = value;
+    if(!this.bulkSet) this.prefsChanged.next( this.toJSONObject() );
+  }
+  /** color of link lines that are not directly connected to a focal entity */
+  public get indirectLinkColor(): string | undefined {
+    return this._indirectLinkColor;
+  }
+  /** color of link lines that are not directly connected to a focal entity */
+  public set indirectLinkColor(value: string | undefined) {
+    this._indirectLinkColor = value;
     if(!this.bulkSet) this.prefsChanged.next( this.toJSONObject() );
   }
   /** whether or not to ignore the maxEntities value and always get 

--- a/src/lib/services/sz-prefs.service.ts
+++ b/src/lib/services/sz-prefs.service.ts
@@ -883,6 +883,8 @@ export class SzGraphPrefs extends SzSdkPrefsBase {
   private _unlimitedMaxEntities: boolean = true;
   /** @internal */
   private _unlimitedMaxScope: boolean = false;
+  /** @internal */
+  private _suppressL1InterLinks: boolean = true;
 
   /** the keys of member setters or variables in the object
    * to output in json, or to take as json input
@@ -903,7 +905,8 @@ export class SzGraphPrefs extends SzSdkPrefsBase {
     'neverFilterQueriedEntityIds',
     'queriedEntitiesColor',
     'unlimitedMaxEntities',
-    'unlimitedMaxScope'
+    'unlimitedMaxScope',
+    'suppressL1InterLinks'
   ]
 
   // -------------- getters and setters
@@ -1058,6 +1061,17 @@ export class SzGraphPrefs extends SzSdkPrefsBase {
    * build out to max */
   public set unlimitedMaxScope(value: boolean) {
     this._unlimitedMaxScope = value;
+    if(!this.bulkSet && this._rememberStateOptions) this.prefsChanged.next( this.toJSONObject() );
+  }
+  /** whether or not to ignore the maxDegreesOfSeparation value and always get 
+   * build out to max */
+   public get suppressL1InterLinks(): boolean {
+    return this._suppressL1InterLinks;
+  }
+  /** whether or not to ignore the maxDegreesOfSeparation value and always get 
+   * build out to max */
+  public set suppressL1InterLinks(value: boolean) {
+    this._suppressL1InterLinks = value;
     if(!this.bulkSet && this._rememberStateOptions) this.prefsChanged.next( this.toJSONObject() );
   }
 

--- a/src/lib/why/sz-why-entities.component.ts
+++ b/src/lib/why/sz-why-entities.component.ts
@@ -77,26 +77,28 @@ export class SzWhyEntitiesComparisonComponent implements OnInit, OnDestroy {
     this._isLoading = true;
     this.loading.emit(true);
 
-    this.getWhyData()
-    .subscribe((resData: SzWhyEntitiesResponse) => {
-      this._isLoading = false;
-      this.loading.emit(false);
-
-      if(resData.data.entities && resData.data.entities.length > 0) {
-        resData.data.entities.forEach((_data: SzEntityData) => {
-          if(_data.resolvedEntity && _data.resolvedEntity.records) {
-            //matchedRecords = matchedRecords.concat(_data.resolvedEntity.records);
-          }
-        });
-      }
-      let formattedData = this.formatWhyDataForDataTable(resData.data);
-      this._columnsToDisplay  = formattedData.columns;
-      this.dataToDisplay      = formattedData.data;
-      this.dataSource.setData(this.dataToDisplay);
-      this.gotColumnDefs = true;
-    }, (error) => {
-      console.warn(error);
-    });
+    if(this.entityIds && this.entityIds.length == 2) {
+      this.getWhyData()
+      .subscribe((resData: SzWhyEntitiesResponse) => {
+        this._isLoading = false;
+        this.loading.emit(false);
+  
+        if(resData.data.entities && resData.data.entities.length > 0) {
+          resData.data.entities.forEach((_data: SzEntityData) => {
+            if(_data.resolvedEntity && _data.resolvedEntity.records) {
+              //matchedRecords = matchedRecords.concat(_data.resolvedEntity.records);
+            }
+          });
+        }
+        let formattedData = this.formatWhyDataForDataTable(resData.data);
+        this._columnsToDisplay  = formattedData.columns;
+        this.dataToDisplay      = formattedData.data;
+        this.dataSource.setData(this.dataToDisplay);
+        this.gotColumnDefs = true;
+      }, (error) => {
+        console.warn(error);
+      });
+    }
   }
   /**
    * unsubscribe when component is destroyed

--- a/src/package.json
+++ b/src/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@senzing/sdk-components-ng",
-  "version": "5.1.1",
+  "version": "5.1.1-beta.1",
   "private": false,
   "keywords" :["Angular","Library","Senzing"],
   "license" : "SEE LICENSE IN LICENSE",


### PR DESCRIPTION
# Pull request questions

## Which issue does this address

resolves #407 
resolves #413 
resolves #414 
resolves #415 
resolves #417 

## Why was change needed

#407 changes the graph network calls to a composite pattern to better handle entities with large amounts of relationships. Initial testing for an entity with >1k related entities went from 45s before render to 12s.

## What does change improve

### Added
- Added "hide indirect links" UI control to graph filtering component.
- Added `suppressL1InterLinks` to graph preferences
- Added `linkColor` to graph preferences
- Added `indirectLinkColor` to graph preferences
- Added *Link Color* section to graph filter component
- Added *Data Sources* list to graph hover tooltip

### Modified
- `showMatchKeys` UI/UX parameter renamed to `showLinkLabels` to avoid confusion with `matchKeyFilters` and `showMatchKeyTokens` which are functional/behavior parameters.
- Graph api call pattern changed to an initial entity request followed by a minimal `entity-networks` call to retrieve the necessary data. This new surface pattern dramatically decreases the time needed to initially render a graph with a large about of relationships.
- Graph entity name label no longer clips with ellipsis.
- Graph entity name now performs a hard word wrap to display the full name on multiple lines
