### PR TITLE
#416 new way to do user defined graph node colors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 [markdownlint](https://dlaa.me/markdownlint/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [5.1.1] - 2022-09-28
+## [5.1.1] - 2022-10-03
 
 
 ### Added
@@ -26,7 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Graph entity name label no longer clips with ellipsis.
 - Graph entity name now performs a hard word wrap to display the full name on multiple lines
 
-relevant tickets: #309 #364 #383 #407 #413 #414 #415 #417 #422 #423
+relevant tickets: #309 #364 #383 #407 #413 #414 #415 #416 #417 #422 #423
 
 
 ## [5.1.0] - 2022-07-27

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Graph entity name label no longer clips with ellipsis.
 - Graph entity name now performs a hard word wrap to display the full name on multiple lines
 
-relevant tickets: #309 #364 #383 #407 #413 #414 #415 #417
+relevant tickets: #309 #364 #383 #407 #413 #414 #415 #417 #422 #423
 
 
 ## [5.1.0] - 2022-07-27

--- a/examples/search-in-graph/src/app/app.component.html
+++ b/examples/search-in-graph/src/app/app.component.html
@@ -48,7 +48,7 @@
         [filterControlPosition]="'top-right'"
         (entityClick)="onGraphEntityClick($event)"
         (contextMenuClick)="onGraphContextClick($event)"
-        [showMatchKeys]="true"
+        [showLinkLabels]="true"
         [showMatchKeyFilters]="false"
         [showMatchKeyTokenFilters]="true"
         [showCoreMatchKeyTokenChips]="true"

--- a/examples/search-in-graph/src/app/app.component.ts
+++ b/examples/search-in-graph/src/app/app.component.ts
@@ -29,9 +29,9 @@ export class AppComponent implements AfterViewInit {
   public unsubscribe$ = new Subject<void>();
   public currentSearchResults: SzAttributeSearchResult[];
   public currentlySelectedEntityId: number;
-  //public searchResultEntityIds: SzEntityIdentifier[] = [40002];
+  public searchResultEntityIds: SzEntityIdentifier[] = [300002];
   //public searchResultEntityIds: SzEntityIdentifier[] = [39001,40002,40003,40005];
-  public searchResultEntityIds: SzEntityIdentifier[] = [40001,40003,40005,41001,44271];
+  //public searchResultEntityIds: SzEntityIdentifier[] = [40001,40003,40005,41001,44271];
   public currentSearchParameters: SzEntitySearchParams;
   public showSearchResults = true;
   public showSpinner = false;

--- a/src/lib/entity/detail/sz-entity-detail-graph/sz-entity-detail-graph.component.ts
+++ b/src/lib/entity/detail/sz-entity-detail-graph/sz-entity-detail-graph.component.ts
@@ -6,6 +6,7 @@ import {
 import { SzGraphNodeFilterPair, SzNetworkGraphInputs } from '../../../models/graph';
 import { SzPrefsService } from '../../../services/sz-prefs.service';
 import { SzGraphComponent } from '../../../graph/sz-graph.component';
+import { SzCSSClassService } from '../../../services/sz-css-class.service';
 
 /**
  * @internal
@@ -74,9 +75,10 @@ export class SzEntityDetailGraphComponent extends SzGraphComponent {
 
   constructor(
     public _p_prefs: SzPrefsService,
-    private _p_cd: ChangeDetectorRef
+    private _p_cd: ChangeDetectorRef,
+    private _p_css: SzCSSClassService
   ) {
-    super(_p_prefs, _p_cd)
+    super(_p_prefs, _p_cd, _p_css)
   }
 
   /** toggle collapsed/expanded state of graph */

--- a/src/lib/entity/detail/sz-entity-detail-graph/sz-standalone-graph.component.ts
+++ b/src/lib/entity/detail/sz-entity-detail-graph/sz-standalone-graph.component.ts
@@ -8,6 +8,7 @@ import { SzWhyEntitiesDialog } from '../../../why/sz-why-entities.component';
 import { Overlay, OverlayRef } from '@angular/cdk/overlay';
 import { MatDialog } from '@angular/material/dialog';
 import { SzMatchKeyTokenFilterScope } from '../../../models/graph';
+import { SzCSSClassService } from '../../../services/sz-css-class.service';
 
 /**
  * Embeddable Graph Component
@@ -102,11 +103,12 @@ export class SzStandaloneGraphComponent extends SzGraphComponent implements Afte
   constructor(
     public _p_prefs: SzPrefsService,
     private _p_cd: ChangeDetectorRef,
+    private _p_css: SzCSSClassService,
     public overlay: Overlay,
     public dialog: MatDialog,
     public viewContainerRef: ViewContainerRef
   ) {
-    super(_p_prefs, _p_cd)
+    super(_p_prefs, _p_cd, _p_css)
   }
 
   ngAfterViewInit() {

--- a/src/lib/graph/sz-graph-filter.component.ts
+++ b/src/lib/graph/sz-graph-filter.component.ts
@@ -517,6 +517,9 @@ export class SzGraphFilterComponent implements OnInit, AfterViewInit, OnDestroy 
     console.log('onColorParameterChange: ', prefName, value, this.prefs.graph.suppressL1InterLinks);
     try {
       this.prefs.graph[prefName] = value;
+      if(prefName === 'queriedEntitiesColor'){
+        this.prefs.graph.focusedEntitiesColor
+      }
     } catch(err) {}
   }
   /** handler method for when a basic bool pref should be toggled */

--- a/src/lib/graph/sz-graph-filter.component.ts
+++ b/src/lib/graph/sz-graph-filter.component.ts
@@ -180,7 +180,7 @@ export class SzGraphFilterComponent implements OnInit, AfterViewInit, OnDestroy 
         // assume it's already cast correctly
         this._matchKeyTokenSelectionScope = (value as SzMatchKeyTokenFilterScope);
     }
-    console.log(`@senzing/sdk-components-ng/sz-graph-filter.matchKeyTokenSelectionScope(${value} | ${(this._matchKeyTokenSelectionScope as unknown as string)})`, this._matchKeyTokenSelectionScope);
+    //console.log(`@senzing/sdk-components-ng/sz-graph-filter.matchKeyTokenSelectionScope(${value} | ${(this._matchKeyTokenSelectionScope as unknown as string)})`, this._matchKeyTokenSelectionScope);
   }
   /**
    * get the value of match key token filterings scope. possible values are 
@@ -548,7 +548,7 @@ export class SzGraphFilterComponent implements OnInit, AfterViewInit, OnDestroy 
 
   /** proxy handler for when prefs have changed externally */
   private onPrefsChange(prefs: any) {
-    this._showLinkLabels        = prefs.showMatchKeys;
+    this._showLinkLabels        = prefs.showLinkLabels;
     this._suppressL1InterLinks  = prefs.suppressL1InterLinks
     this.maxDegreesOfSeparation = prefs.maxDegreesOfSeparation;
     this.maxEntities            = prefs.maxEntities;
@@ -763,13 +763,6 @@ export class SzGraphFilterComponent implements OnInit, AfterViewInit, OnDestroy 
     }
     //console.log('@senzing/sdk-components-ng/sz-entity-detail-graph-filter.removeAllMatchKeyControls: ', this.filterByMatchKeysData, this.matchKeysIncluded);
   }
-  /*
-  private removeAllMatchKeyTokenControls() {
-    while(this.filterByMatchKeyTokenData.length > 0){
-      this.filterByMatchKeyTokenData.removeAt(this.filterByMatchKeyTokenData.length - 1);
-    }
-    //console.log('@senzing/sdk-components-ng/sz-entity-detail-graph-filter.removeAllMatchKeyControls: ', this.filterByMatchKeysData, this.matchKeysIncluded);
-  }*/
 
   private initializeMatchKeysFormControls() {
     //console.log('@senzing/sdk-components-ng/sz-entity-detail-graph-filter.initializeMatchKeysFormControls: ', this.matchKeys, this.showMatchKeys, this.matchKeysIncluded);
@@ -786,22 +779,6 @@ export class SzGraphFilterComponent implements OnInit, AfterViewInit, OnDestroy 
       });
     }
   }
-  /*
-  private initializeMatchKeyTokenFormControls() {
-    console.log('@senzing/sdk-components-ng/sz-entity-detail-graph-filter.initializeMatchKeysFormControls: ', this.matchKeyTokens, this.showMatchKeyTokens, this.matchKeyTokensIncluded);
-    if(this.matchKeyTokens) {
-      // remove old controls
-      this.removeAllMatchKeyTokenControls();
-
-      // init form controls for filter by match keys
-      this.matchKeyTokens.forEach((o, i) => {
-        const mkFilterVal = (this.matchKeyTokensIncluded.indexOf(o.name) >= 0);
-        const control1 = new FormControl(mkFilterVal); // if first item set to true, else false
-        // add control for filtered by list
-        (this.filterByMatchKeyTokensForm.controls['matchkeytokens'] as FormArray).push(control1);
-      });
-    }
-  }*/
 
   /** helper method for retrieving list of datasources */
   public getDataSources() {

--- a/src/lib/graph/sz-graph.component.ts
+++ b/src/lib/graph/sz-graph.component.ts
@@ -28,7 +28,7 @@ import { SzCSSClassService } from '../services/sz-css-class.service';
           [showFiltersControl]="false"
           [filterControlPosition]="'top-right'"
           (entityClick)="onGraphEntityClick($event)"
-          [showMatchKeys]="true"
+          [showLinkLabels]="true"
       ></sz-graph>
  *
  * @example <!-- (WC) by attribute -->
@@ -39,7 +39,7 @@ import { SzCSSClassService } from '../services/sz-css-class.service';
           show-match-key-control="false"
           show-filters-control="false"
           filter-control-position="top-right"
-          show-match-keys="true"
+          show-link-labels="true"
       ></sz-wc-graph>
  *
  * @example <!-- (WC) by DOM -->
@@ -624,12 +624,10 @@ export class SzGraphComponent implements OnInit, OnDestroy {
       this.clearMatchKeyFilters();
       this.matchKeysChange.emit( SzRelationshipNetworkComponent.getMatchKeysFromEntityNetworkData(inputs.data) )
       this.matchKeyTokensChange.emit( matchKeyTokens );
-      console.log('onGraphDataLoaded: ', _matchKeyTokens, this.filterShowMatchKeyTokens, inputs);
     }
     if(inputs.data) {
       this.dataLoaded.emit( inputs.data );
     }
-    console.log('onGraphDataLoaded setter: ', inputs);
   }
   /**
    * when new data has been added to the initial data request
@@ -723,7 +721,6 @@ export class SzGraphComponent implements OnInit, OnDestroy {
   }
 
   public onOptionChange(event: {name: string, value: any}) {
-    console.log('onOptionChange: ', event);
     switch(event.name) {
       case 'showLinkLabels':
         this.showLinkLabels = event.value;

--- a/src/lib/graph/sz-graph.component.ts
+++ b/src/lib/graph/sz-graph.component.ts
@@ -940,13 +940,15 @@ export class SzGraphComponent implements OnInit, OnDestroy {
       if(prefs.queriedEntitiesColor) {
         this.graphContainerEle.nativeElement.style.setProperty('--sz-graph-queried-entity-color', prefs.queriedEntitiesColor);
       }
-      if(prefs.dataSourceColors) {
-        //console.warn('doing ds colors!! ');
-        prefs.dataSourceColors.forEach((dsColorEntry: SzDataSourceComposite) => {
+      if(prefs.dataSourceColors && prefs.dataSourceColors.sort) {
+        let sorted = Array.from(prefs.dataSourceColors)
+        .sort((dsColorEntry1: SzDataSourceComposite, dsColorEntry2: SzDataSourceComposite) => {
+          let retVal = dsColorEntry1.index > dsColorEntry2.index ? -1 : (dsColorEntry1.index < dsColorEntry2.index) ? 1 : 0 ;
+          return retVal;
+        })
+        .forEach((dsColorEntry: SzDataSourceComposite) => {
           this.cssClassesService.setStyle(`.sz-node-ds-${dsColorEntry.name.toLowerCase()}`, "fill", dsColorEntry.color);
           this.cssClassesService.setStyle(`.sz-node-ds-${dsColorEntry.name.toLowerCase()} .sz-graph-node-icon`, "fill", dsColorEntry.color);
-
-          //console.log(`\tadded ".sz-node-ds-${dsColorEntry.name.toLowerCase()}" class`);
         })
       }
     }

--- a/src/lib/graph/sz-graph.component.ts
+++ b/src/lib/graph/sz-graph.component.ts
@@ -8,6 +8,7 @@ import { SzGraphNodeFilterPair, SzEntityNetworkMatchKeyTokens, SzMatchKeyTokenCo
 import { SzRelationshipNetworkComponent } from './sz-relationship-network/sz-relationship-network.component';
 import { parseBool, parseSzIdentifier, sortDataSourcesByIndex } from '../common/utils';
 import { SzDataSourceComposite } from '../models/data-sources';
+import { SzCSSClassService } from '../services/sz-css-class.service';
 
 /**
  * Embeddable Graph Component
@@ -781,7 +782,8 @@ export class SzGraphComponent implements OnInit, OnDestroy {
 
   constructor(
     public prefs: SzPrefsService,
-    private cd: ChangeDetectorRef
+    private cd: ChangeDetectorRef,
+    private cssClassesService: SzCSSClassService
   ) {}
 
   /**
@@ -932,8 +934,20 @@ export class SzGraphComponent implements OnInit, OnDestroy {
       if(prefs.indirectLinkColor) {
         this.graphContainerEle.nativeElement.style.setProperty('--sz-graph-link-line-non-focused-color', prefs.indirectLinkColor);
       }
+      if(prefs.focusedEntitiesColor) {
+        this.graphContainerEle.nativeElement.style.setProperty('--sz-graph-focused-entity-color', prefs.focusedEntitiesColor);
+      }
       if(prefs.queriedEntitiesColor) {
-        this.graphContainerEle.nativeElement.style.setProperty('--sz-graph-focused-entity-color', prefs.queriedEntitiesColor);
+        this.graphContainerEle.nativeElement.style.setProperty('--sz-graph-queried-entity-color', prefs.queriedEntitiesColor);
+      }
+      if(prefs.dataSourceColors) {
+        //console.warn('doing ds colors!! ');
+        prefs.dataSourceColors.forEach((dsColorEntry: SzDataSourceComposite) => {
+          this.cssClassesService.setStyle(`.sz-node-ds-${dsColorEntry.name.toLowerCase()}`, "fill", dsColorEntry.color);
+          this.cssClassesService.setStyle(`.sz-node-ds-${dsColorEntry.name.toLowerCase()} .sz-graph-node-icon`, "fill", dsColorEntry.color);
+
+          //console.log(`\tadded ".sz-node-ds-${dsColorEntry.name.toLowerCase()}" class`);
+        })
       }
     }
 

--- a/src/lib/graph/sz-relationship-network/sz-relationship-network.component.ts
+++ b/src/lib/graph/sz-relationship-network/sz-relationship-network.component.ts
@@ -1367,9 +1367,6 @@ export class SzRelationshipNetworkComponent implements AfterViewInit, OnDestroy 
       //this.getNetwork(this._entityIds, this._maxDegrees, _maxBuildOut, _maxEntities).pipe(
         takeUntil(this.unsubscribe$),
         first(),
-        tap( (resp: any) => {
-          console.info('getNetwork()', resp);
-        }),
         map( this.asGraphInputs.bind(this) ),
         tap( (gdata: SzNetworkGraphInputs) => {
           //console.warn('SzRelationshipNetworkGraph: g1 = ', gdata);
@@ -1507,7 +1504,7 @@ export class SzRelationshipNetworkComponent implements AfterViewInit, OnDestroy 
       let entityResp    = responses[0] as SzEntityResponse;
       let networkResp   = responses[1] as SzEntityNetworkResponse;
       let modifiedResp  = this.mergeEntityResponseWithNetworkResponse(entityResp, networkResp);
-      console.info('getNetworkComposite: ', responses, modifiedResp);
+      //console.info('getNetworkComposite: ', responses, modifiedResp);
 
       if(console.time){
         try {
@@ -3246,7 +3243,6 @@ export class SzRelationshipNetworkComponent implements AfterViewInit, OnDestroy 
         relatedToPrimaryEntities = relatedToPrimaryEntities.concat( entNode.relatedEntities.map((relEnt) => { return relEnt.entityId; }) );
       }
     });
-    console.log('SzRelationshipNetworkGraph.asGraph: ', inputs, data, entitiesData, entityPaths, primaryEntityIds);
 
     // Identify queried nodes and the nodes and links that connect them.
     entityPaths.forEach( (entPath) => {

--- a/src/lib/scss/graph.scss
+++ b/src/lib/scss/graph.scss
@@ -18,6 +18,19 @@ body {
         stroke: #474747;
       }
     }
+
+    &.sz-graph-primary-node {
+      fill: var(--sz-graph-primary-entity-color);
+      .sz-graph-node-icon {
+        fill: var(--sz-graph-primary-entity-color);
+      }
+    }
+    &.sz-graph-focused-node {
+      fill: var(--sz-graph-focused-entity-color);
+      .sz-graph-node-icon {
+        fill: var(--sz-graph-focused-entity-color);
+      }
+    }
   }
 
   // for core non-removable nodes we dont want to show

--- a/src/lib/sdk.module.ts
+++ b/src/lib/sdk.module.ts
@@ -25,6 +25,7 @@ import { SzPrefsService } from './services/sz-prefs.service';
 import { SzDataSourcesService } from './services/sz-datasources.service';
 import { SzAdminService } from './services/sz-admin.service';
 import { SzBulkDataService } from './services/sz-bulk-data.service';
+import { SzCSSClassService } from './services/sz-css-class.service';
 
 /** components */
 import { SzMultiSelectButtonComponent } from './shared/multi-select-button/multi-select-button.component';
@@ -209,6 +210,7 @@ const SzRestConfigurationInjector = new InjectionToken<SzRestConfiguration>("SzR
     SzAdminService,
     SzBulkDataService,
     SzConfigurationService,
+    SzCSSClassService,
     SzDataSourcesService,
     SzFoliosService,
     SzPrefsService,

--- a/src/lib/services/sz-css-class.service.ts
+++ b/src/lib/services/sz-css-class.service.ts
@@ -1,0 +1,71 @@
+import { Injectable } from '@angular/core';
+
+/**
+ * A service that provides the capability to "dynamically" add CSS
+ * classes to the head of the document or app
+ *
+ * @export
+ */
+@Injectable({
+  providedIn: 'root'
+})
+export class SzCSSClassService {
+  private _headElement: HTMLHeadElement;
+  private _styleSheetTitle: string = 'senzing-dyn-css-classing';
+  private _styleSheet: CSSStyleSheet;
+
+  private get headElement(): HTMLHeadElement {
+    if(!this._headElement && document.getElementsByTagName("head").length > 0) {
+      this._headElement = document.getElementsByTagName("head")[0];
+    }
+    return this._headElement;
+  }
+
+  private get styleSheet(): CSSStyleSheet {
+    if(!this._styleSheet) {
+      if(!document.styleSheets || this.headElement === null) return null;
+
+      // get stylesheet that matches the "_styleSheetTitle" value
+      this._styleSheet = Array.from(document.styleSheets)
+      .find(s => s.title === this._styleSheetTitle);
+
+      if(!this._styleSheet) {
+        console.warn('initialized dyn css block');
+        this._styleSheet = this.initCssBlock();
+      }
+    }
+
+    return this._styleSheet;
+  }
+
+  constructor() {}
+
+  /** initialize the dyn classing block */
+  private initCssBlock(): CSSStyleSheet {
+    // Create the style sheet element.
+    let cssEle = document.createElement("style");
+    cssEle.type   = "text/css";
+    cssEle.title  = this._styleSheetTitle;
+
+    // Append the style sheet element to the head.
+    this.headElement.appendChild(cssEle);
+    return cssEle.sheet as CSSStyleSheet;
+  }
+
+  public setStyle(selectorText: string, styleName: string, value: string): void {
+    let rules: CSSRuleList = this.styleSheet.cssRules.length > 0 || this.styleSheet.rules.length == 0 ? this.styleSheet.cssRules : this.styleSheet.rules;
+    let ruleIndex: number  = Array.from(rules).findIndex(r => r instanceof CSSStyleRule && r.selectorText.toLowerCase() == selectorText.toLowerCase());
+    let rule: CSSStyleRule = Array.from(rules)[ruleIndex] as CSSStyleRule;
+
+    if(!styleName || !value){ return; }
+
+    if(!rule){ 
+      // create 
+      let newRuleIndex = this.styleSheet.insertRule(selectorText + `{ ${styleName}: ${value}}`, rules.length);
+      return; 
+    } else {
+      this.styleSheet.deleteRule(ruleIndex);
+      this.styleSheet.insertRule(selectorText + `{ ${styleName}: ${value}}`, rules.length);
+    }
+  }
+}

--- a/src/lib/services/sz-css-class.service.ts
+++ b/src/lib/services/sz-css-class.service.ts
@@ -30,7 +30,6 @@ export class SzCSSClassService {
       .find(s => s.title === this._styleSheetTitle);
 
       if(!this._styleSheet) {
-        console.warn('initialized dyn css block');
         this._styleSheet = this.initCssBlock();
       }
     }
@@ -44,7 +43,6 @@ export class SzCSSClassService {
   private initCssBlock(): CSSStyleSheet {
     // Create the style sheet element.
     let cssEle = document.createElement("style");
-    cssEle.type   = "text/css";
     cssEle.title  = this._styleSheetTitle;
 
     // Append the style sheet element to the head.

--- a/src/lib/services/sz-prefs.service.ts
+++ b/src/lib/services/sz-prefs.service.ts
@@ -881,6 +881,8 @@ export class SzGraphPrefs extends SzSdkPrefsBase {
   /** @internal */
   private _queriedEntitiesColor: string | undefined = "#465BA8";
   /** @internal */
+  private _focusedEntitiesColor: string | undefined = "#465BA8";
+  /** @internal */
   private _linkColor: string | undefined = "#999";
   /** @internal */
   private _indirectLinkColor: string | undefined = "#999";
@@ -911,6 +913,7 @@ export class SzGraphPrefs extends SzSdkPrefsBase {
     'matchKeyCoreTokensIncluded',
     'neverFilterQueriedEntityIds',
     'queriedEntitiesColor',
+    'focusedEntitiesColor',
     'linkColor',
     'indirectLinkColor',
     'unlimitedMaxEntities',
@@ -1049,6 +1052,15 @@ export class SzGraphPrefs extends SzSdkPrefsBase {
   /** color of active or queried for entity or entitities */
   public set queriedEntitiesColor(value: string | undefined) {
     this._queriedEntitiesColor = value;
+    if(!this.bulkSet) this.prefsChanged.next( this.toJSONObject() );
+  }
+  /** color of focused/expanded entity or entitities */
+  public get focusedEntitiesColor(): string | undefined {
+    return this._focusedEntitiesColor;
+  }
+  /** color of focused/expanded entity or entitities */
+  public set focusedEntitiesColor(value: string | undefined) {
+    this._focusedEntitiesColor = value;
     if(!this.bulkSet) this.prefsChanged.next( this.toJSONObject() );
   }
   /** color of link lines */


### PR DESCRIPTION
# Pull request questions

## Which issue does this address

resolves #416 

## Why was change needed

when a user would change a parameter or a method was called internally that caused a re-paint sometimes color information that was applied to each graph node programatically was lost if the appropriate color subroutine was not called during or after the other method call. using this new methodology no color information is stored on the nodes themselves, the node(s) are tagged with css class names that represent a attribute that can be colored, then a css class that matches that selector is injected in to the head of the document. no subsequent repaint's are necessary and selecting and crawling all the graph nodes to assign color information is no longer necessary(which may have a minor perf benefit)

## What does change improve

performance and method of how we "color" specific elements in the graph experience
