### PR TITLE
#439 why not added to possible matches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 [markdownlint](https://dlaa.me/markdownlint/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [5.1.1] - 2022-10-03
+## [5.1.1] - 2022-10-31
 
 
 ### Added
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `indirectLinkColor` to graph preferences
 - Added *Link Color* section to graph filter component
 - Added *Data Sources* list to graph hover tooltip
+- Added "Why Not" button/report to "Possible Matches" section in the entity detail component.
 
 ### Modified
 - Match keys on graph entity link(s) are now in a vertically centered multi-line list.
@@ -26,7 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Graph entity name label no longer clips with ellipsis.
 - Graph entity name now performs a hard word wrap to display the full name on multiple lines
 
-relevant tickets: #309 #364 #383 #407 #413 #414 #415 #416 #417 #422 #423
+relevant tickets: #309 #364 #383 #407 #413 #414 #415 #416 #417 #422 #423 #432 #433 #439
 
 
 ## [5.1.0] - 2022-07-27

--- a/src/lib/entity/detail/sz-entity-detail.component.html
+++ b/src/lib/entity/detail/sz-entity-detail.component.html
@@ -71,11 +71,14 @@
     [sectionTitle]="'Possible Matches'"
     sectionId="detail-section-2"
     [sectionCount]="this._possibleMatches?.length"
+    [showWhyUtilities]="showRelatedWhyNotFunction"
+    [whySelectionMode]="whySelectionMode"
     [forceLayout]="_forceLayout"
     [layoutClasses]="_layoutEnforcers"
     [showNameDataInEntities]="showNameDataInPossibleMatchesSection"
     (onCollapsedChange)="this.onSectionCollapsedChange('possibleMatches', $event)"
-    (entityRecordClick)="onEntityRecordClick($event)">
+    (entityRecordClick)="onEntityRecordClick($event)"
+    (onCompareEntitiesForWhyNot)="onCompareEntitiesForWhyNot($event)">
   </sz-entity-details-section>
   <sz-entity-details-section class="details-section discovered"
     *ngIf="this._discoveredRelationships?.length && this.showPossibleRelationshipsSection"
@@ -88,7 +91,10 @@
     [forceLayout]="_forceLayout"
     [layoutClasses]="_layoutEnforcers"
     [showNameDataInEntities]="showNameDataInPossibleRelationshipsSection"
-    (entityRecordClick)="onEntityRecordClick($event)">
+    [showWhyUtilities]="showRelatedWhyNotFunction"
+    [whySelectionMode]="whySelectionMode"
+    (entityRecordClick)="onEntityRecordClick($event)"
+    (onCompareEntitiesForWhyNot)="onCompareEntitiesForWhyNot($event)">
   </sz-entity-details-section>
   <sz-entity-details-section class="details-section disclosed"
     *ngIf="this._disclosedRelationships?.length && this.showDisclosedSection"

--- a/src/lib/entity/detail/sz-entity-detail.component.ts
+++ b/src/lib/entity/detail/sz-entity-detail.component.ts
@@ -133,6 +133,7 @@ export class SzEntityDetailComponent implements OnInit, OnDestroy, AfterViewInit
   private _whySelectionMode: SzWhySelectionModeBehavior = SzWhySelectionMode.NONE;
   private _showEntityWhyFunction: boolean = false;
   private _showRecordWhyUtilities: boolean = false;
+  private _showRelatedWhyNotUtilities: boolean = false;
   private _openWhyComparisonModalOnClick: boolean = true;
   // graph utilities
   private _showGraphNodeContextMenu: boolean = false;
@@ -146,6 +147,8 @@ export class SzEntityDetailComponent implements OnInit, OnDestroy, AfterViewInit
   @Output() headerWhyButtonClick = new EventEmitter<SzEntityIdentifier>();
   /** (Event Emitter) when the user clicks on the "Why" button in records section */
   @Output() recordsWhyButtonClick = new EventEmitter<SzRecordId[]>();
+  /** (Event Emitter) when the user clicks on the "Why Not" button in a related entity card */
+  @Output() relatedEntitiesWhyNotButtonClick = new EventEmitter<SzEntityIdentifier[]>();
   /** (Event Emitter) when the user clicks on a datasource record for either single-select
    * or multi-select operations.
    */
@@ -228,6 +231,14 @@ export class SzEntityDetailComponent implements OnInit, OnDestroy, AfterViewInit
   /** whether or not to show the "why" comparison button for the entire entity */
   @Input() set showEntityWhyFunction(value: boolean) {
     this._showEntityWhyFunction = value;
+  }
+  /** whether or not the "why" comparison button on "possible matches" */
+  public get showRelatedWhyNotFunction(): boolean {
+    return this._showRelatedWhyNotUtilities;
+  }
+  /** whether or not to show the "why not" comparison button on "possible matches" */
+  @Input() set showRelatedWhyNotFunction(value: boolean) {
+    this._showRelatedWhyNotUtilities = value;
   }
   /** whether or not to automatically open a modal with the entity comparison on 
    * "Why" button click. (disable for custom implementation/action)
@@ -769,7 +780,7 @@ export class SzEntityDetailComponent implements OnInit, OnDestroy, AfterViewInit
    */
   public onHeaderWhyButtonClick(entityId: SzEntityIdentifier){
     this.headerWhyButtonClick.emit(entityId);
-    console.log('SzEntityDetailComponent.onHeaderWhyButtonClick: ', entityId);
+    //console.log('SzEntityDetailComponent.onHeaderWhyButtonClick: ', entityId);
     if(this._openWhyComparisonModalOnClick){
       this.dialog.open(SzWhyEntityDialog, {
         panelClass: 'why-entity-dialog-panel',
@@ -783,7 +794,7 @@ export class SzEntityDetailComponent implements OnInit, OnDestroy, AfterViewInit
   }
 
   public onCompareRecordsForWhy(records: SzRecordId[]) {
-    console.log('SzEntityDetailComponent.onCompareRecordsForWhy: ', records);
+    //console.log('SzEntityDetailComponent.onCompareRecordsForWhy: ', records);
     this.recordsWhyButtonClick.emit(records);
     if(this._openWhyComparisonModalOnClick) {
       this.dialog.open(SzWhyEntityDialog, {
@@ -795,6 +806,27 @@ export class SzEntityDetailComponent implements OnInit, OnDestroy, AfterViewInit
           showOkButton: false,
           okButtonText: 'Close',
           records: records
+        }
+      });
+    }
+  }
+
+  public onCompareEntitiesForWhyNot(entityIds: any) {
+    console.log('SzEntityDetailComponent.onCompareEntitiesForWhyNot: ', entityIds, this._openWhyComparisonModalOnClick);
+    if(entityIds && entityIds.length > 0 && entityIds.push){
+      entityIds.push(this.entity.resolvedEntity.entityId);
+    }
+    
+    this.relatedEntitiesWhyNotButtonClick.emit(entityIds);
+    if(this._openWhyComparisonModalOnClick) {
+      this.dialog.open(SzWhyEntitiesDialog, {
+        panelClass: 'why-entities-dialog-panel',
+        minHeight: 400,
+        minWidth: 800,
+        data: {
+          entities: entityIds,
+          showOkButton: false,
+          okButtonText: 'Close'
         }
       });
     }

--- a/src/lib/entity/detail/sz-entity-details-section/collapsible-card.component.html
+++ b/src/lib/entity/detail/sz-entity-details-section/collapsible-card.component.html
@@ -73,9 +73,12 @@
               [entity]="_cardData"
               [parentEntity]="cardData"
               [layoutClasses]="layoutClasses"
-              [ngClass]="{'open': expanded, 'no-shade': true}"
+              [ngClass]="{'open': expanded, 'no-shade': true, 'selected': isRelatedEntitySelected(_cardData), 'select-mode-single': isSingleSelect, 'select-mode-multiple': isMultiSelect, 'is-selectable': relatedWhyNotSelectActive}"
+              [whySelectionMode]="whySelectionMode"
+              [whySelectionAction]="'WHY_NOT'"
               [truncateResults]="truncateResults"
               [truncatedTooltip]="'click to expand.'"
+              (onWhyNotClicked)="onEntityRecordWhyNotClicked($event)"
             ></sz-entity-record-card-content>
           </div>
       </div>
@@ -94,6 +97,7 @@
           [parentEntity]="cardData"
           [ngClass]="{'open': expanded, 'selected': isRecordSelected(_cardData), 'select-mode-single': isSingleSelect, 'select-mode-multiple': isMultiSelect, 'is-selectable': recordWhySelectActive}"
           [whySelectionMode]="whySelectionMode"
+          [whySelectionAction]="'WHY'"
           [layoutClasses]="layoutClasses"
           [truncateResults]="truncateResults"
           [truncatedTooltip]="'click to expand.'"

--- a/src/lib/entity/detail/sz-entity-details-section/sz-entity-details-section.component.html
+++ b/src/lib/entity/detail/sz-entity-details-section/sz-entity-details-section.component.html
@@ -45,8 +45,11 @@
       [showOtherDataInEntities]="showOtherDataInEntities"
       [showBestNameOnlyinEntities]="showBestNameOnlyInEntities"
       [showNameDataInEntities]="showNameDataInEntities"
+      [whySelectionMode]="whySelectionMode"
       (onCollapsedChange)="this.onCollapsibleCardStateChange($event)"
+      (onCompareEntitiesForWhyNot)="_onCompareEntitiesForWhyNot($event)"
       (entityRecordClick)="onEntityRecordClick($event)"
+      (entityRecordWhyNotClick)="onEntityRecordWhyNotClick($event)"
       class="by-match-key">
     </sz-entity-detail-section-collapsible-card>
   </ng-container>
@@ -61,10 +64,13 @@
       [collapsedStatePrefsKey]="this.collapsedStatePrefsKey"
       [layoutClasses]="_layoutClasses"
       (onCollapsedChange)="this.onCollapsibleCardStateChange($event)"
+      (onCompareEntitiesForWhyNot)="_onCompareEntitiesForWhyNot($event)"
       [truncateResults]="true"
       [showBestNameOnlyinEntities]="showBestNameOnlyInEntities"
       [showNameDataInEntities]="showNameDataInEntities"
-      (entityRecordClick)="onEntityRecordClick($event)">
+      [whySelectionMode]="whySelectionMode"
+      (entityRecordClick)="onEntityRecordClick($event)"
+      (entityRecordWhyNotClick)="onEntityRecordWhyNotClick($event)">
     </sz-entity-detail-section-collapsible-card>
   </ng-container>
 </div>

--- a/src/lib/entity/sz-entity-record-card/sz-entity-record-card-content/sz-entity-record-card-content.component.html
+++ b/src/lib/entity/sz-entity-record-card/sz-entity-record-card-content/sz-entity-record-card-content.component.html
@@ -58,7 +58,7 @@
 </div>
 <!--<div class="select-mode-single-hover-mask">-->
   <button 
-      class="select-mode-single-hover-button"
+      class="select-mode-single-hover-button select-mode-action-why"
       mat-stroked-button
       matTooltipPosition="above"
       matTooltip="Perform Why Analysis on this record"
@@ -67,4 +67,14 @@
       aria-hidden="false" aria-label="Click to perform Why on record"
       >compare_arrows</mat-icon> Why?
   </button>
+  <button 
+  class="select-mode-single-hover-button select-mode-action-why-not"
+  mat-stroked-button
+  matTooltipPosition="above"
+  matTooltip="Perform Why Not Analysis between this entity and the one you are currently viewing"
+  (click)="onRelatedEntityCardWhyNotClicked($event)">
+  <mat-icon  
+  aria-hidden="false" aria-label="Click to perform Why Not on between this entity and the one you are currently viewing"
+  >compare_arrows</mat-icon> Why?
+</button>
 <!--</div>-->

--- a/src/lib/entity/sz-entity-record-card/sz-entity-record-card-content/sz-entity-record-card-content.component.ts
+++ b/src/lib/entity/sz-entity-record-card/sz-entity-record-card-content/sz-entity-record-card-content.component.ts
@@ -6,12 +6,13 @@ import {
   SzResolvedEntity,
   SzEntityRecord,
   SzRelatedEntity,
-  SzRecordId
+  SzRecordId,
+  SzEntityIdentifier
 } from '@senzing/rest-api-client-ng';
 import { Subject, BehaviorSubject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
 import { SzPrefsService } from '../../../services/sz-prefs.service';
-import { SzWhySelectionMode, SzWhySelectionModeBehavior } from '../../../models/data-source-record-selection';
+import { SzWhySelectionMode, SzWhySelectionAction, SzWhySelectionModeBehavior, SzWhySelectionActionBehavior } from '../../../models/data-source-record-selection';
 
 
 /**
@@ -36,6 +37,8 @@ export class SzEntityRecordCardContentComponent implements OnInit {
   private _showBestNameOnly: boolean = false;
   private _ignorePrefOtherDataChanges = false;
   @Input() public whySelectionMode: SzWhySelectionModeBehavior = SzWhySelectionMode.NONE;
+  @Input() public whySelectionAction: SzWhySelectionActionBehavior = SzWhySelectionAction.NONE;
+
   @Input() public showWhyUtilities: boolean = false;
   @Input() public showRecordIdWhenNative: boolean = false;
   /** allows records with empty columns to match up with records with non-empty columns. format is [true,false,true,true,true] */
@@ -526,6 +529,17 @@ export class SzEntityRecordCardContentComponent implements OnInit {
       this.onRecordCardWhyClickedEmitter.emit(recordId);
     } else {
       console.error('SzEntityRecordCardContentComponent.onRecordCardWhyClicked() ERROR: datasource or recordId missing');
+    }
+  }
+  @Output('onWhyNotClicked') 
+  onWhyNotClickedEmitter: EventEmitter<SzEntityIdentifier> = new EventEmitter<SzEntityIdentifier>();
+
+  public onRelatedEntityCardWhyNotClicked(event: any) {
+    console.log('SzEntityRecordCardContentComponent.onRelatedEntityCardWhyNotClicked()', this.entity, this);
+    if(this.entity && this.entity.entityId) {
+      this.onWhyNotClickedEmitter.emit(this.entity.entityId)
+    } else {
+      console.error('SzEntityRecordCardContentComponent.onRelatedEntityCardWhyNotClicked() ERROR: entityId missing');
     }
   }
 }

--- a/src/lib/models/data-source-record-selection.ts
+++ b/src/lib/models/data-source-record-selection.ts
@@ -5,6 +5,13 @@ export interface SzDataSourceRecordSelection {
     [key: string]: Array<string|number> 
 }
 
+export type SzWhySelectionActionBehavior = 'WHY' | 'WHY_NOT' | 'NONE';
+export const SzWhySelectionAction = {
+    WHY: 'WHY' as SzWhySelectionActionBehavior,
+    WHY_NOT: 'WHY_NOT' as SzWhySelectionActionBehavior,
+    NONE: 'NONE' as SzWhySelectionActionBehavior
+}
+
 export type SzWhySelectionModeBehavior = 'SINGLE' | 'MULTI' | 'NONE';
 export const SzWhySelectionMode = {
     SINGLE: 'SINGLE' as SzWhySelectionModeBehavior,


### PR DESCRIPTION
# Pull request questions

## Which issue does this address

resolves #439 

## Why was change needed

we wanted to expose the "why not" report through the UI in the entity detail component.

## What does change improve

users can now click on the "why not" button in the "possible matches" section of the detail component to show a report comparing why the current entity and the related entity did not resolve to a single unified entity.
