### PR TITLE
updates to angular material@15 syntax/modules

### DIFF
--- a/src/lib/entity/detail/sz-entity-detail-graph/sz-standalone-graph.component.ts
+++ b/src/lib/entity/detail/sz-entity-detail-graph/sz-standalone-graph.component.ts
@@ -6,7 +6,7 @@ import { TemplatePortal } from '@angular/cdk/portal';
 import { SzEntityIdentifier } from '@senzing/rest-api-client-ng';
 import { SzWhyEntitiesDialog } from '../../../why/sz-why-entities.component';
 import { Overlay, OverlayRef } from '@angular/cdk/overlay';
-import { MatLegacyDialog as MatDialog } from '@angular/material/legacy-dialog';
+import { MatDialog } from '@angular/material/dialog';
 import { SzMatchKeyTokenFilterScope } from '../../../models/graph';
 import { SzCSSClassService } from '../../../services/sz-css-class.service';
 

--- a/src/lib/entity/detail/sz-entity-detail-header/header.component.ts
+++ b/src/lib/entity/detail/sz-entity-detail-header/header.component.ts
@@ -1,7 +1,7 @@
 import { Component, OnInit, Input, OnDestroy, EventEmitter, Output } from '@angular/core';
 import { SzEntityDetailSectionSummary } from '../../../models/entity-detail-section-data';
 import { BreakpointObserver, BreakpointState } from '@angular/cdk/layout';
-import { MatLegacyDialog as MatDialog } from '@angular/material/legacy-dialog';
+import { MatDialog } from '@angular/material/dialog';
 import { Subject, BehaviorSubject } from 'rxjs';
 import { takeUntil, filter } from 'rxjs/operators';
 

--- a/src/lib/entity/detail/sz-entity-detail.component.ts
+++ b/src/lib/entity/detail/sz-entity-detail.component.ts
@@ -14,7 +14,7 @@ import {
   SzEntityIdentifier,
   SzRecordId
 } from '@senzing/rest-api-client-ng';
-import { MatLegacyDialog as MatDialog } from '@angular/material/legacy-dialog';
+import { MatDialog } from '@angular/material/dialog';
 
 import { SzEntityDetailGraphComponent } from './sz-entity-detail-graph/sz-entity-detail-graph.component';
 import { SzWhyEntityDialog } from '../../why/sz-why-entity.component';

--- a/src/lib/graph/sz-graph-filter.component.html
+++ b/src/lib/graph/sz-graph-filter.component.html
@@ -10,7 +10,7 @@
             Show Match Keys
             <span class="tooltip tooptip-left">display match keys on relationship lines</span>
           </span>
-          <span class="left-adjusted no-text"><mat-checkbox [checked]="showLinkLabels" (change)="onCheckboxPrefToggle('showLinkLabels',$event.checked)"></mat-checkbox></span>
+          <span class="left-adjusted no-text"><mat-checkbox class="unpadded" [checked]="showLinkLabels" (change)="onCheckboxPrefToggle('showLinkLabels',$event.checked)"></mat-checkbox></span>
         </div>
       </label>
     </li>
@@ -31,7 +31,7 @@
             Hide Indirect Links
             <span class="tooltip tooptip-left">do not show inter-related first level links</span>
           </span>
-          <span class="left-adjusted no-text"><mat-checkbox [checked]="suppressL1InterLinks" (change)="onCheckboxPrefToggle('suppressL1InterLinks',$event.checked)"></mat-checkbox></span>
+          <span class="left-adjusted no-text"><mat-checkbox class="unpadded" [checked]="suppressL1InterLinks" (change)="onCheckboxPrefToggle('suppressL1InterLinks',$event.checked)"></mat-checkbox></span>
         </div>
       </label>
     </li>
@@ -42,15 +42,13 @@
             Scope
             <span class="tooltip tooptip-left">number of relationship hops away from focused entity</span>
           </span>
-          <span class="left-adjusted"><mat-checkbox [checked]="unlimitedMaxScope" (change)="onMaxUnlimitedChange('unlimitedMaxScope',$event.checked)">unlimited</mat-checkbox></span>
+          <span class="left-adjusted"><mat-checkbox class="unpadded" [checked]="unlimitedMaxScope" (change)="onMaxUnlimitedChange('unlimitedMaxScope',$event.checked)">unlimited</mat-checkbox></span>
         </div>
       </label>
       <label class="slider-row" *ngIf="!unlimitedMaxScope">
         <mat-slider style="width: 100%" min="1" [max]="buildOutMax" 
-        [disabled]="unlimitedMaxScope" 
-        [value]="buildOut"
-        (change)="onIntParameterChange('buildOut', $event.value)"
-        ></mat-slider>
+        [disabled]="unlimitedMaxScope"
+         #ngSlider><input matSliderThumb [value]="buildOut" (change)="onIntParameterChange('buildOut', {source: ngSliderThumb, parent: ngSlider, value: ngSliderThumb.value}.value)" #ngSliderThumb="matSliderThumb" /></mat-slider>
         <!--<input type="range" [min]="buildOutMin" [max]="buildOutMax" formControlName="buildOut" [value]="buildOut" 
           (change)="onIntParameterChange('buildOut', getValueFromEventTarget($event))" required>-->
         <span class="intVal">({{ buildOut }})</span>
@@ -63,15 +61,13 @@
             Max
             <span class="tooltip tooptip-left">hard limit on how many entities will be displayed</span>
           </span>
-          <span class="left-adjusted"><mat-checkbox [checked]="unlimitedMaxEntities" (change)="onMaxUnlimitedChange('unlimitedMaxEntities',$event.checked)">unlimited</mat-checkbox></span>
+          <span class="left-adjusted"><mat-checkbox class="unpadded" [checked]="unlimitedMaxEntities" (change)="onMaxUnlimitedChange('unlimitedMaxEntities',$event.checked)">unlimited</mat-checkbox></span>
         </div>
       </label>
       <label class="slider-row" *ngIf="!unlimitedMaxEntities" style="display: flex; flex-direction: row; justify-content: space-between; align-content: center; flex-wrap: nowrap; align-items: center;">
         <mat-slider style="width: 100%" min="1" [max]="maxEntitiesLimit + 3" step="3" 
-        [disabled]="unlimitedMaxEntities" 
-        [value]="maxEntities"
-        (change)="onIntParameterChange('maxEntities', $event.value)"
-        ></mat-slider>
+        [disabled]="unlimitedMaxEntities"
+         #ngSlider><input matSliderThumb [value]="maxEntities" (change)="onIntParameterChange('maxEntities', {source: ngSliderThumb, parent: ngSlider, value: ngSliderThumb.value}.value)" #ngSliderThumb="matSliderThumb" /></mat-slider>
         <!--<input type="range" 
           min="1" [max]="maxEntitiesLimit + 3" 
           [disabled]="true"
@@ -206,31 +202,39 @@
       class="match-key-token-mode-select" 
       [checked]="isMatchKeyTokenSelectionScopeCore"
       (change)="onMatchKeyCoreModeToggle($event.checked)">Directly Related Only</mat-slide-toggle>
-    <mat-chip-list 
+    <mat-chip-listbox 
       #matchKeyChipList
+      multiple
       class="match-keys mat-chip-list-stacked" 
       aria-orientation="vertical" 
       aria-label="Match Key Filters">
       
       <div *ngIf="isMatchKeyTokenSelectionScopeCore" class="chip-group core">
-        <mat-chip *ngFor="let mk of matchKeyCoreTokens; let i = index"
+        <!--matchKeyCoreTokensIncluded: {{matchKeyCoreTokensIncluded}}<br/>-->
+        <mat-chip-option *ngFor="let mk of matchKeyCoreTokens; let i = index"
           class="core-key"
           [class.selected]="isMatchKeyCoreTokenSelected(mk.name)"
           (click)="onCoreMkTagFilterToggle(mk.name)"
-          [matBadge]="getMKBadgeCount(mk.coreCount)" matBadgePosition="after" matBadgeColor="accent">
+          disableRipple="true"
+          leadingIcon="false"
+          [matBadge]="getMKBadgeCount(mk.coreCount)" 
+          matBadgePosition="after" 
+          matBadgeColor="accent">
           {{mk.name}}
-        </mat-chip>
+        </mat-chip-option>
       </div>
       <div *ngIf="!isMatchKeyTokenSelectionScopeCore" class="chip-group extraneous">
-        <mat-chip *ngFor="let mk of matchKeyTokens; let i = index"
+        <mat-chip-option *ngFor="let mk of matchKeyTokens; let i = index"
           class="extra-key"
           [class.selected]="isMatchKeyTokenSelected(mk.name)"
           (click)="onMkTagFilterToggle(mk.name)"
+          disableRipple="true"
+          leadingIcon="false"
           [matBadge]="getMKBadgeCount(mk.count)" matBadgePosition="after" matBadgeColor="accent">
           {{mk.name}}
-        </mat-chip>
+        </mat-chip-option>
       </div>
-    </mat-chip-list>
+    </mat-chip-listbox>
     <!--<form [formGroup]="filterByMatchKeyTokensForm">
     <ul class="filters-list">
       <ng-container *ngFor="let ds of filterByMatchKeyTokenData.controls; let i = index">

--- a/src/lib/graph/sz-graph-filter.component.scss
+++ b/src/lib/graph/sz-graph-filter.component.scss
@@ -178,22 +178,45 @@
   .match-key-token-mode-select {
     display: block;
     margin-bottom: 20px;
+    
+    /*
+    .mdc-switch__handle-track {
+      border: 1px solid green;
+      &::after {
+        color: rgb(28, 122, 151) !important;
+        background-color: rgb(28, 122, 151) !important;
+      }
+    }
+    .mdc-switch__track
+    .mdc-switch__track::after,
+    .mdc-switch__handle-track {
+      color: rgb(28, 122, 151);
+    }
+    */
   }
 
-  mat-chip-list.match-keys {
+  mat-chip-listbox.match-keys {
+    --mdc-chip-elevated-container-color: var(--sz-graph-filter-match-key-tags-selected-color);
+    --mdc-chip-elevated-disabled-container-color: #eee;
+    --mdc-chip-label-text-color: #fff;
 
-    mat-chip {
+    mat-chip-option {
       font-size: var(--sz-graph-filter-match-key-tags-font-size);
       line-height: var(--sz-graph-filter-match-key-tags-line-height);
       padding: var(--sz-graph-filter-match-key-tags-padding);
       margin-right: var(--sz-graph-filter-match-key-tags-margin-right);
       display: inline-block;
       width: var(--sz-graph-filter-match-key-tags-width);
+      height: var(--sz-graph-filter-match-key-tags-height);
       min-height: var(--sz-graph-filter-match-key-tags-min-height);
       color: var(--sz-graph-filter-match-key-tags-color);
       background-color: var(--sz-graph-filter-match-key-tags-background-color);
       cursor: var(--sz-graph-filter-match-key-tags-cursor);
       user-select: none;
+
+      button.mat-mdc-chip-action {
+        padding-right: 9px;
+      }
 
       &.selected {
         background-color: var(--sz-graph-filter-match-key-tags-selected-background-color); //rgb(208, 224, 228);
@@ -203,17 +226,7 @@
         &.core-key {
           background-color: var(--sz-graph-filter-match-key-core-tags-selected-background-color);
         }
-      }
-
-      .mat-badge-content {
-        background-color: var(--sz-graph-filter-match-key-tags-count-badge-background-color);
-        color: var(--sz-graph-filter-match-key-tags-count-badge-color);
-        top: var(--sz-graph-filter-match-key-tags-count-badge-top);
-        right: var(--sz-graph-filter-match-key-tags-count-badge-right);
-        width: unset;
-        min-width: var(--sz-graph-filter-match-key-tags-min-width);
-        padding: 0 3px;
-      }
+      }      
     }
   }
 }

--- a/src/lib/graph/sz-graph-filter.component.ts
+++ b/src/lib/graph/sz-graph-filter.component.ts
@@ -416,18 +416,18 @@ export class SzGraphFilterComponent implements OnInit, AfterViewInit, OnDestroy 
         // remove from position
         _matchKeyTokensIncludedMemCopy.splice(_existingKeyPos,1);
         this.prefs.graph.matchKeyTokensIncluded = _matchKeyTokensIncludedMemCopy;
-        //console.log(`@senzing/sdk-components-ng/sz-entity-detail-graph-filter.onMkTagFilterToggle: removed ${mkName} from cloud value`,_matchKeyTokensIncludedMemCopy);
+        console.log(`@senzing/sdk-components-ng/sz-entity-detail-graph-filter.onMkTagFilterToggle: removed ${mkName} from cloud value`,_matchKeyTokensIncludedMemCopy);
       } else {
         // add to included token list
         _matchKeyTokensIncludedMemCopy.push( mkName );
         this.prefs.graph.matchKeyTokensIncluded = _matchKeyTokensIncludedMemCopy;
-        //console.log(`@senzing/sdk-components-ng/sz-entity-detail-graph-filter.onMkTagFilterToggle: added ${mkName} to cloud value`,_matchKeyTokensIncludedMemCopy);
+        console.log(`@senzing/sdk-components-ng/sz-entity-detail-graph-filter.onMkTagFilterToggle: added ${mkName} to cloud value`,_matchKeyTokensIncludedMemCopy);
       }
     } else {
       // add to included token list
       _matchKeyTokensIncludedMemCopy.push( mkName );
       this.prefs.graph.matchKeyTokensIncluded = _matchKeyTokensIncludedMemCopy;
-      //console.log(`@senzing/sdk-components-ng/sz-entity-detail-graph-filter.onMkTagFilterToggle: added ${mkName} to cloud value`,_matchKeyTokensIncludedMemCopy);
+      console.log(`@senzing/sdk-components-ng/sz-entity-detail-graph-filter.onMkTagFilterToggle: added ${mkName} to cloud value`,_matchKeyTokensIncludedMemCopy);
     }
   }
   onCoreMkTagFilterToggle( mkName: string ) { 
@@ -443,6 +443,7 @@ export class SzGraphFilterComponent implements OnInit, AfterViewInit, OnDestroy 
       // now that we have a clean array see if the current value has 
       // an existing position
       let _existingKeyPos = _matchKeyTokensIncludedMemCopy.indexOf(mkName);
+      console.log(`@senzing/sdk-components-ng/sz-entity-detail-graph-filter.onCoreMkTagFilterToggle: checking if "${mkName}" is in existing items: ${_matchKeyTokensIncludedMemCopy}`, _existingKeyPos);
       if(_existingKeyPos > -1 && _matchKeyTokensIncludedMemCopy[_existingKeyPos]) {
         // remove from position
         _matchKeyTokensIncludedMemCopy.splice(_existingKeyPos,1);
@@ -455,6 +456,7 @@ export class SzGraphFilterComponent implements OnInit, AfterViewInit, OnDestroy 
         console.log(`@senzing/sdk-components-ng/sz-entity-detail-graph-filter.onCoreMkTagFilterToggle: addeded ${mkName}(${_existingKeyPos}) to cloud value`,_matchKeyTokensIncludedMemCopy);
       }
     } else {
+      console.log(`matchKeyCoreTokensIncluded: ${this.matchKeyCoreTokensIncluded}`);
       // add to included token list
       _matchKeyTokensIncludedMemCopy.push( mkName );
       this.prefs.graph.matchKeyCoreTokensIncluded = _matchKeyTokensIncludedMemCopy;

--- a/src/lib/scss/styles.scss
+++ b/src/lib/scss/styles.scss
@@ -17,8 +17,15 @@
 }
 
 body {
-  
+  /*
+  --sz-graph-filter-match-key-mode-select-track-color: #414141;
+  --sz-graph-filter-match-key-mode-select-handle-color: rgb(219, 219, 219);
+  --sz-graph-filter-match-key-mode-select-active-track-color: #{$sz-blue};
+  --sz-graph-filter-match-key-mode-select-active-handle-color: #{$sz-blue};
+  */
+
   /* match key tag cloud for standalone graph and filter(s) */
+  /* TODO(mdc-migration): The following rule targets internal classes of chips that may no longer apply for the MDC version. */
   mat-chip-list.match-keys .mat-chip-list-wrapper,
   mat-chip-list.match-keys .chip-group {
     display: var(--sz-graph-filter-match-key-tags-display);
@@ -49,12 +56,138 @@ body {
   }
 
 }
+
+.mat-mdc-slide-toggle.match-key-token-mode-select {
+  display: block;
+  margin-bottom: 20px;
+
+  .mdc-switch {
+    .mdc-switch__track {
+      &::after, &::before {
+        background: var(--sz-graph-filter-match-key-mode-select-track-color) !important;
+      }
+    }
+    .mdc-switch__handle {
+      &::before, &::after {
+        background: var(--sz-graph-filter-match-key-mode-select-handle-color) !important;
+      }
+    }
+
+    &:hover {
+      .mdc-switch__handle {
+        &::before, &::after {
+          background: var(--sz-graph-filter-match-key-mode-select-handle-color) !important;
+        }
+      }
+    }
+
+    &.mdc-switch--selected {
+      .mdc-switch__track {
+        &::after, &::before {
+          background: var(--sz-graph-filter-match-key-mode-select-active-track-color) !important;
+        }
+      }
+      .mdc-switch__handle {
+        &::before, &::after {
+          background: var(--sz-graph-filter-match-key-mode-select-active-handle-color) !important;
+        }
+      }
+  
+      &:hover {
+        .mdc-switch__handle {
+          &::before, &::after {
+            background: var(--sz-graph-filter-match-key-mode-select-active-handle-color) !important;
+          }
+        }
+      }
+    }
+
+  }
+  .mdc-switch {
+    .mdc-switch__handle-track .mdc-switch__ripple {
+      display: none;
+    }
+    /*
+      .mdc-switch__track {
+        &::after, &::before {
+          background: var(--sz-graph-filters-match-key-mode-select-track-color);
+        }
+      }
+      .mdc-switch__handle {
+        &::before, &::after {
+          background: var(--sz-graph-filter-match-key-mode-select-handle-color);
+        }
+      }
+    
+    &:hover {
+      .mdc-switch__track {
+        &::after, &::before {
+          background: var(--sz-graph-filters-match-key-mode-select-track-color);
+        }
+      }
+      .mdc-switch__handle {
+        &::before, &::after {
+          background: var(--sz-graph-filter-match-key-mode-select-handle-color);
+        }
+      }
+    }
+    &.mdc-switch--selected {
+      .mdc-switch__track {
+        &::after, &::before {
+          background: var(--sz-graph-filter-match-key-mode-select-active-track-color);
+        }
+      }
+      .mdc-switch__handle {
+        &::before, &::after {
+          background: var(--sz-graph-filter-match-key-mode-select-active-handle-color);
+        }
+      }
+      &:hover {
+        .mdc-switch__track {
+          &::after, &::before {
+            background: var(--sz-graph-filter-match-key-mode-select-active-track-color);
+          }
+        }
+        .mdc-switch__handle {
+          &::before, &::after {
+            background: var(--sz-graph-filter-match-key-mode-select-active-handle-color);
+          }
+        }
+      }
+    }
+    */
+  }
+}
+mat-chip-listbox.match-keys {
+  mat-chip-option {
+    .mat-mdc-chip-graphic {
+      display: none !important;
+    }
+    .mat-badge-content {
+      background-color: var(--sz-graph-filter-match-key-tags-count-badge-background-color);
+      color: var(--sz-graph-filter-match-key-tags-count-badge-color);
+      top: var(--sz-graph-filter-match-key-tags-count-badge-top) !important;
+      right: var(--sz-graph-filter-match-key-tags-count-badge-right) !important;
+      width: unset;
+      min-width: var(--sz-graph-filter-match-key-tags-min-width);
+      padding: 0 3px;
+    }
+  }
+}
+.mat-mdc-checkbox.unpadded .mdc-checkbox {
+  padding: 0px;
+  .mdc-checkbox__background {
+    top: auto;
+    left: auto;
+  }
+}
+
 .why-entity-dialog-panel, .why-entities-dialog-panel {
   max-width: 100vw !important;
   max-height: 100vh !important;
   width: unset !important;
   height: unset !important;
-  .mat-dialog-container {
+  .mat-mdc-dialog-container {
     padding: 0px;
     //height: 500px;  /* this is actually min-height because of the way material-dialogs work */
     //width: 900px;   /* this is actually min-width because of the way material-dialogs work */
@@ -65,12 +198,18 @@ body {
 .alert-dialog-panel, .alert-dialog-panel {
   max-width: 100vw !important;
   max-height: 100vh;
-  .mat-dialog-container {
+  .mat-mdc-dialog-container {
     padding: 0px;
     overflow: hidden;
     max-height: 100vh;
   }
 }
+.mat-mdc-dialog-container {
+  .mdc-dialog__title::before {
+    display: none;
+  }
+}
+
 
 .senzing-alarm:before {
   content: "\e900";

--- a/src/lib/scss/theme.scss
+++ b/src/lib/scss/theme.scss
@@ -11,9 +11,13 @@
 //  If you specify typography styles for the components you use elsewhere, you should delete this line.
 //  If you don't need the default component typographies but still want the hierarchy styles,
 //  you can delete this line and instead use:
-//    `@include mat.legacy-typography-hierarchy(mat.define-legacy-typography-config());`
-@include mat.all-legacy-component-typographies();
-@include mat.legacy-core();
+//    `@include mat.legacy-typography-hierarchy(mat.define-typography-config());`
+/*TODO(mdc-migration): Remove all-legacy-component-typographies once all legacy components are migrated*/
+//@include mat.all-legacy-component-typographies();
+@include mat.all-component-typographies();
+/*TODO(mdc-migration): Remove legacy-core once all legacy components are migrated*/
+//@include mat.legacy-core();
+@include mat.core();
 
 // --------------------- ANGULAR MATERIAL THEME
 // Define the palettes for your theme using the Material Design palettes available in palette.scss
@@ -58,7 +62,10 @@ $sz-mat-theme: mat.define-light-theme((
   )
 ));
 
+/*TODO(mdc-migration): Remove all-legacy-component-themes once all legacy components are migrated*/
 @include mat.all-legacy-component-themes($sz-mat-theme);
+
+@include mat.all-component-themes($sz-mat-theme);
 //@include mat.core-theme($sz-mat-theme);
 //@include mat.button-theme($sz-mat-theme);
 
@@ -371,12 +378,12 @@ body {
     --sz-graph-filter-match-key-tags-display: inline-flex;
     --sz-graph-filter-match-key-tags-flex-direction: column;
     --sz-graph-filter-match-key-tags-align-items: flex-start;
-    --sz-graph-filter-match-key-tags-font-size: 10px;
+    --sz-graph-filter-match-key-tags-font-size: 11px;
     --sz-graph-filter-match-key-tags-line-height: inherit;
-    --sz-graph-filter-match-key-tags-padding: 4px 40px 4px 12px;
-    --sz-graph-filter-match-key-tags-margin-right: 20px;
+    --sz-graph-filter-match-key-tags-padding: 2px 26px 2px 12px;
+    --sz-graph-filter-match-key-tags-margin-right: 4px;
     --sz-graph-filter-match-key-tags-width: unset;
-    --sz-graph-filter-match-key-tags-min-height: 26px;
+    --sz-graph-filter-match-key-tags-min-height: 10px;
     --sz-graph-filter-match-key-tags-min-width: 22px;
     --sz-graph-filter-match-key-tags-color: #525252;
     --sz-graph-filter-match-key-tags-background-color: #e0e0e0;
@@ -384,11 +391,15 @@ body {
     --sz-graph-filter-match-key-tags-selected-background-color: rgb(208, 224, 228);
     --sz-graph-filter-match-key-tags-selected-color: inherit;
     --sz-graph-filter-match-key-tags-selected-cursor: pointer;
-    --sz-graph-filter-match-key-tags-count-badge-top: 2px;
+    --sz-graph-filter-match-key-tags-count-badge-top: calc(50% - 11px);
     --sz-graph-filter-match-key-tags-count-badge-right: 3px;
     --sz-graph-filter-match-key-tags-count-badge-background-color: #ffffffbd;
     --sz-graph-filter-match-key-tags-count-badge-color: inheirit;
     --sz-graph-filter-match-key-core-tags-selected-background-color: rgb(238, 238, 164);
+    --sz-graph-filter-match-key-mode-select-track-color: #00000061;
+    --sz-graph-filter-match-key-mode-select-handle-color: rgb(219, 219, 219);
+    --sz-graph-filter-match-key-mode-select-active-track-color: rgba(15, 158, 247, 0.31);
+    --sz-graph-filter-match-key-mode-select-active-handle-color: #{$sz-blue};
 
   /* end entity detail vars */
   /* start preferences component */

--- a/src/lib/sdk.material.module.ts
+++ b/src/lib/sdk.material.module.ts
@@ -3,22 +3,22 @@ import { CommonModule } from '@angular/common';
 import { DragDropModule } from '@angular/cdk/drag-drop';
 import { MatBadgeModule } from '@angular/material/badge';
 import { MatBottomSheetModule } from '@angular/material/bottom-sheet';
-import { MatLegacyButtonModule as MatButtonModule } from '@angular/material/legacy-button';
-import { MatLegacyCheckboxModule as MatCheckboxModule } from '@angular/material/legacy-checkbox';
-import { MatLegacyChipsModule as MatChipsModule } from '@angular/material/legacy-chips'
-import { MatLegacyDialogModule as MatDialogModule } from '@angular/material/legacy-dialog';
+import { MatButtonModule } from '@angular/material/button';
+import { MatCheckboxModule } from '@angular/material/checkbox';
+import { MatChipsModule } from '@angular/material/chips'
+import { MatDialogModule } from '@angular/material/dialog';
 import { MatGridListModule } from '@angular/material/grid-list';
 import { MatIconModule } from '@angular/material/icon';
-import { MatLegacyInputModule as MatInputModule } from '@angular/material/legacy-input'
-import { MatLegacyMenuModule as MatMenuModule } from '@angular/material/legacy-menu';
-import { MatLegacyPaginatorModule as MatPaginatorModule } from '@angular/material/legacy-paginator';
+import { MatInputModule } from '@angular/material/input'
+import { MatMenuModule } from '@angular/material/menu';
+import { MatPaginatorModule } from '@angular/material/paginator';
 import { MatSidenavModule } from '@angular/material/sidenav';
-import { MatLegacySliderModule as MatSliderModule } from '@angular/material/legacy-slider';
-import { MatLegacySlideToggleModule as MatSlideToggleModule } from '@angular/material/legacy-slide-toggle';
+import { MatSliderModule } from '@angular/material/slider';
+import { MatSlideToggleModule } from '@angular/material/slide-toggle';
 import { MatSortModule } from '@angular/material/sort';
-import { MatLegacyTableModule as MatTableModule } from '@angular/material/legacy-table';
+import { MatTableModule } from '@angular/material/table';
 import { MatToolbarModule } from '@angular/material/toolbar';
-import { MatLegacyTooltipModule as MatTooltipModule } from '@angular/material/legacy-tooltip';
+import { MatTooltipModule } from '@angular/material/tooltip';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 
 @NgModule({

--- a/src/lib/search/sz-search-results/sz-search-results.component.ts
+++ b/src/lib/search/sz-search-results/sz-search-results.component.ts
@@ -10,7 +10,7 @@ import {
 import { SzPrefsService, SzSearchResultsPrefs } from '../../services/sz-prefs.service';
 import { Subject } from 'rxjs';
 import { take, takeUntil } from 'rxjs/operators';
-import { MatLegacyDialog as MatDialog } from '@angular/material/legacy-dialog';
+import { MatDialog } from '@angular/material/dialog';
 import { SzWhyEntitiesDialog } from '../../why/sz-why-entities.component';
 import { SzAlertMessageDialog } from '../../shared/alert-dialog/sz-alert-dialog.component';
 import { parseBool } from '../../common/utils';

--- a/src/lib/search/sz-search/sz-search-identifiers-picker.component.scss
+++ b/src/lib/search/sz-search/sz-search-identifiers-picker.component.scss
@@ -13,7 +13,7 @@
         display: none;
     }
 
-    .mat-dialog-actions {
+    .mat-mdc-dialog-actions {
         /*position: absolute;
         bottom: 0px;
         display: flex;*/
@@ -54,7 +54,7 @@
         margin-bottom: 20px;
     }
 
-    .mat-dialog-actions {
+    .mat-mdc-dialog-actions {
         display: flex;
         width: 100%;
         position: absolute;
@@ -67,11 +67,11 @@
     }
 }
 
-:host ::ng-deep .mat-dialog-content {
+:host ::ng-deep .mat-mdc-dialog-content {
     height: calc(100% - 96px);
 }
 
-:host.isMatSheet ::ng-deep .mat-dialog-content {
+:host.isMatSheet ::ng-deep .mat-mdc-dialog-content {
     height: calc(100vh - 32px - 0.67em - 0.67em - 16px);
     max-height: calc(100vh - 32px - 0.67em - 0.67em - 16px);
 

--- a/src/lib/search/sz-search/sz-search-identifiers-picker.component.ts
+++ b/src/lib/search/sz-search/sz-search-identifiers-picker.component.ts
@@ -1,6 +1,6 @@
 
 import { Component, HostBinding, Inject } from '@angular/core';
-import { MatLegacyDialogRef as MatDialogRef, MAT_LEGACY_DIALOG_DATA as MAT_DIALOG_DATA} from '@angular/material/legacy-dialog';
+import { MatDialogRef, MAT_DIALOG_DATA} from '@angular/material/dialog';
 import { MatBottomSheetRef, MAT_BOTTOM_SHEET_DATA} from '@angular/material/bottom-sheet';
 
 import { SzAttributeType } from '@senzing/rest-api-client-ng';

--- a/src/lib/search/sz-search/sz-search.component.ts
+++ b/src/lib/search/sz-search/sz-search.component.ts
@@ -3,7 +3,7 @@ import { UntypedFormBuilder, UntypedFormGroup } from '@angular/forms';
 import { Subject  } from 'rxjs';
 import { map, first, filter, takeUntil } from 'rxjs/operators';
 import { BreakpointObserver, BreakpointState } from '@angular/cdk/layout';
-import { MatLegacyDialog as MatDialog } from '@angular/material/legacy-dialog';
+import { MatDialog } from '@angular/material/dialog';
 import { MatBottomSheet } from '@angular/material/bottom-sheet';
 
 import {

--- a/src/lib/shared/alert-dialog/sz-alert-dialog.component.scss
+++ b/src/lib/shared/alert-dialog/sz-alert-dialog.component.scss
@@ -3,7 +3,7 @@
     position: relative;
     height: 100%;
 
-    .mat-dialog-title {
+    .mat-mdc-dialog-title {
         background-color: #6d738c;
         text-align: center;
         padding: 6px;
@@ -13,13 +13,13 @@
         border-bottom-left-radius: 0;
         border-bottom-right-radius: 0;
     }
-    .mat-dialog-content {
+    .mat-mdc-dialog-content {
         height: calc(100% - 100px);
         width: 100%;
         margin: 0;
         padding: 16px;
     }
-    .mat-dialog-actions {
+    .mat-mdc-dialog-actions {
         justify-content: flex-end;
         padding: 0 0 10px 0;
         margin-bottom: 0px;
@@ -42,7 +42,7 @@
         }
     }
 }
-::ng-deep.mat-dialog-container {
+::ng-deep.mat-mdc-dialog-container {
     resize: both; 
     overflow: auto;
     background: #fff;

--- a/src/lib/shared/alert-dialog/sz-alert-dialog.component.ts
+++ b/src/lib/shared/alert-dialog/sz-alert-dialog.component.ts
@@ -1,5 +1,5 @@
 import { Component, Inject } from '@angular/core';
-import { MAT_LEGACY_DIALOG_DATA as MAT_DIALOG_DATA } from '@angular/material/legacy-dialog';
+import { MAT_DIALOG_DATA } from '@angular/material/dialog';
 
 @Component({
     selector: 'sz-alert-dialog',

--- a/src/lib/shared/multi-select-button/multi-select-button.component.scss
+++ b/src/lib/shared/multi-select-button/multi-select-button.component.scss
@@ -24,7 +24,7 @@
         position: absolute;
         top: calc(50% - (24px / 2));
         }
-        .mat-stroked-button {
+        .mat-mdc-outlined-button {
         position: absolute;
         top: calc(50% - (36px / 2));
         left: 25px;

--- a/src/lib/why/sz-why-entities-dialog.component.scss
+++ b/src/lib/why/sz-why-entities-dialog.component.scss
@@ -8,7 +8,7 @@
         height: 100vh;
     }
 
-    .mat-dialog-title {
+    .mat-mdc-dialog-title {
         background-color: #6d738c;
         text-align: center;
         padding: 6px;
@@ -18,13 +18,13 @@
         border-bottom-left-radius: 0;
         border-bottom-right-radius: 0;
     }
-    .mat-dialog-content {
+    .mat-mdc-dialog-content {
         height: calc(100% - 100px);
         width: 100%;
         margin: 0;
         padding: 0;
     }
-    .mat-dialog-actions {
+    .mat-mdc-dialog-actions {
         justify-content: flex-end;
         padding: 0 0 10px 0;
         margin-bottom: 0px;
@@ -101,7 +101,7 @@
         }
     }
 }
-::ng-deep.mat-dialog-container {
+::ng-deep.mat-mdc-dialog-container {
     resize: both; 
     overflow: auto;
     background: #fff;

--- a/src/lib/why/sz-why-entities.component.scss
+++ b/src/lib/why/sz-why-entities.component.scss
@@ -31,7 +31,7 @@
   text-transform: uppercase;
   font-family: inherit;
 }
-.mat-cell {
+.mat-mdc-cell {
   border-right: 2px solid #dcdcdc;
   padding-left: 16px;
   padding-right: 16px;

--- a/src/lib/why/sz-why-entities.component.ts
+++ b/src/lib/why/sz-why-entities.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnInit, Input, Inject, OnDestroy, Output, EventEmitter, ViewChild, HostBinding, ElementRef, NgZone, AfterViewInit } from '@angular/core';
-import { MAT_LEGACY_DIALOG_DATA as MAT_DIALOG_DATA } from '@angular/material/legacy-dialog';
+import { MAT_DIALOG_DATA } from '@angular/material/dialog';
 import { DataSource } from '@angular/cdk/collections';
 import { EntityDataService, SzDataSourceRecordSummary, SzDetailLevel, SzEntityData, SzEntityFeature, SzEntityIdentifier, SzFeatureMode, SzRecordId, SzWhyEntitiesResponse, SzWhyEntitiesResponseData, SzWhyEntityResponseData } from '@senzing/rest-api-client-ng';
 import { BehaviorSubject, Observable, ReplaySubject, Subject, takeUntil, throwError } from 'rxjs';

--- a/src/lib/why/sz-why-entity-dialog.component.scss
+++ b/src/lib/why/sz-why-entity-dialog.component.scss
@@ -8,7 +8,7 @@
         height: 100vh;
     }
 
-    .mat-dialog-title {
+    .mat-mdc-dialog-title {
         background-color: #6d738c;
         text-align: center;
         padding: 6px;
@@ -18,13 +18,13 @@
         border-bottom-left-radius: 0;
         border-bottom-right-radius: 0;
     }
-    .mat-dialog-content {
+    .mat-mdc-dialog-content {
         height: calc(100% - 100px);
         width: 100%;
         margin: 0;
         padding: 0;
     }
-    .mat-dialog-actions {
+    .mat-mdc-dialog-actions {
         justify-content: flex-end;
         padding: 0 0 10px 0;
         margin-bottom: 0px;
@@ -101,7 +101,7 @@
         }
     }
 }
-::ng-deep.mat-dialog-container {
+::ng-deep.mat-mdc-dialog-container {
     resize: both; 
     overflow: auto;
     background: #fff;

--- a/src/lib/why/sz-why-entity.component.scss
+++ b/src/lib/why/sz-why-entity.component.scss
@@ -44,7 +44,7 @@
   text-transform: uppercase;
   font-family: inherit;
 }
-.mat-cell {
+.mat-mdc-cell {
   border-right: 2px solid #dcdcdc;
   padding-left: 16px;
   padding-right: 16px;

--- a/src/lib/why/sz-why-entity.component.ts
+++ b/src/lib/why/sz-why-entity.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnInit, Input, Inject, OnDestroy, Output, EventEmitter, ViewChild, HostBinding } from '@angular/core';
-import { MatLegacyDialog as MatDialog, MatLegacyDialogRef as MatDialogRef, MAT_LEGACY_DIALOG_DATA as MAT_DIALOG_DATA } from '@angular/material/legacy-dialog';
+import { MatDialog, MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
 import { DataSource } from '@angular/cdk/collections';
 import { EntityDataService, SzAttributeSearchResult, SzDetailLevel, SzEntityData, SzEntityFeature, SzEntityIdentifier, SzFeatureMode, SzFeatureScore, SzFocusRecordId, SzMatchedRecord, SzRecordId, SzWhyEntityResponse, SzWhyEntityResult } from '@senzing/rest-api-client-ng';
 import { Observable, ReplaySubject, Subject } from 'rxjs';


### PR DESCRIPTION
As part of the angular@15 updates the material modules/components made some structural changes that invalidated some of the styling overrides we were using. This brings those components up to date with new selectors/styles.