### PR TITLE
fix graph filter tooltips from getting cut off

### DIFF
--- a/src/lib/entity/detail/sz-entity-detail-graph/sz-entity-detail-graph-filter.component.ts
+++ b/src/lib/entity/detail/sz-entity-detail-graph/sz-entity-detail-graph-filter.component.ts
@@ -1,8 +1,9 @@
-import { Component, ChangeDetectorRef } from '@angular/core';
+import { Component, ChangeDetectorRef, ViewContainerRef } from '@angular/core';
 import { UntypedFormBuilder } from '@angular/forms';
 import { SzPrefsService } from '../../../services/sz-prefs.service';
 import { SzDataSourcesService } from '../../../services/sz-datasources.service';
 import { SzGraphFilterComponent } from '../../../graph/sz-graph-filter.component';
+import { Overlay } from '@angular/cdk/overlay';
 
 /**
  * Control Component allowing UI friendly changes
@@ -35,13 +36,17 @@ export class SzEntityDetailGraphFilterComponent extends SzGraphFilterComponent {
     _p_prefs: SzPrefsService,
     _p_dataSourcesService: SzDataSourcesService,
     _p_formBuilder: UntypedFormBuilder,
-    _p_cd: ChangeDetectorRef
+    _p_cd: ChangeDetectorRef,
+    _p_overlay: Overlay,
+    _p_viewContainerRef: ViewContainerRef,
   ) {
     super(
       _p_prefs, 
       _p_dataSourcesService, 
       _p_formBuilder, 
-      _p_cd
+      _p_cd,
+      _p_overlay,
+      _p_viewContainerRef
     );
   }
 }

--- a/src/lib/entity/detail/sz-entity-detail-graph/sz-standalone-graph.component.html
+++ b/src/lib/entity/detail/sz-entity-detail-graph/sz-standalone-graph.component.html
@@ -71,6 +71,7 @@
         [matchKeyTokenSelectionScope]="matchKeyTokenSelectionScope"
         [showMatchKeyTokenFilters]="showMatchKeyTokenFilters"
         [showMatchKeyTokenSelectAll]="showMatchKeyTokenSelectAll"
+        [showTooltips]="showFilterTooltips"
         [showCoreMatchKeyTokenChips]="showCoreMatchKeyTokenChips"
         [showExtraneousMatchKeyTokenChips]="showExtraneousMatchKeyTokenChips"
         [maxEntitiesLimit]="maxEntitiesFilterLimit"

--- a/src/lib/entity/detail/sz-entity-detail-graph/sz-standalone-graph.component.ts
+++ b/src/lib/entity/detail/sz-entity-detail-graph/sz-standalone-graph.component.ts
@@ -108,7 +108,7 @@ export class SzStandaloneGraphComponent extends SzGraphComponent implements Afte
     public dialog: MatDialog,
     public viewContainerRef: ViewContainerRef
   ) {
-    super(_p_prefs, _p_cd, _p_css)
+    super(_p_prefs, _p_cd, _p_css);
   }
 
   ngAfterViewInit() {

--- a/src/lib/graph/sz-graph-filter.component.html
+++ b/src/lib/graph/sz-graph-filter.component.html
@@ -1,20 +1,25 @@
+<!-- start graph filtering tooltip template -->
+<ng-template #tooltip let-tooltipMessage>
+  <span class="sz-sdk-tooltip tooltip-left">{{tooltipMessage}}</span>
+</ng-template>
+<!-- end   graph filtering tooltip template -->
 <div class="drawer-wrapper">
   <h3>{{ sectionTitles[0] }}</h3>
 
   <form [formGroup]="slidersForm">
   <ul class="sliders-list">
-    <li class="has-tooltip block-level-src no-text-selection">
+    <li class="block-level-src no-text-selection" (mouseenter)="onShowTooltip(ttt1.innerHTML, $event)" (mouseleave)="hideTooltip(ttt1.innerHTML)">
       <label class="checkbox-row">
         <div class="checkbox-row">
-          <span class="has-tooltip">
+          <span>
             Show Match Keys
-            <span class="tooltip tooptip-left">display match keys on relationship lines</span>
+            <span #ttt1 class="tooltip-text">display match keys on relationship lines</span>
           </span>
           <span class="left-adjusted no-text"><mat-checkbox class="unpadded" [checked]="showLinkLabels" (change)="onCheckboxPrefToggle('showLinkLabels',$event.checked)"></mat-checkbox></span>
         </div>
       </label>
     </li>
-    <!--<li class="has-tooltip block-level-src no-text-selection">
+    <!--<li class="block-level-src no-text-selection">
       <span class="tooltip">do not show inter-related first level links</span>
       <label>
         <input type="checkbox"
@@ -24,23 +29,23 @@
         Suppress Indirect Links
       </label>
     </li>-->
-    <li class="has-tooltip block-level-src no-text-selection">
+    <li class="block-level-src no-text-selection" (mouseenter)="onShowTooltip(ttt2.innerHTML, $event)" (mouseleave)="hideTooltip(ttt2.innerHTML)">
       <label class="checkbox-row">
         <div class="checkbox-row">
-          <span class="has-tooltip">
+          <span cclass="has-tooltip">
             Hide Indirect Links
-            <span class="tooltip tooptip-left">do not show inter-related first level links</span>
+            <span #ttt2 class="tooltip-text">do not show inter-related first level links</span>
           </span>
           <span class="left-adjusted no-text"><mat-checkbox class="unpadded" [checked]="suppressL1InterLinks" (change)="onCheckboxPrefToggle('suppressL1InterLinks',$event.checked)"></mat-checkbox></span>
         </div>
       </label>
     </li>
-    <li class="has-tooltip block-level-src no-text-selection">
+    <li class="block-level-src no-text-selection" (mouseenter)="onShowTooltip(ttt3.innerHTML, $event)" (mouseleave)="hideTooltip(ttt3.innerHTML)">
       <label class="checkbox-row">
         <div class="checkbox-row">
-          <span class="has-tooltip">
+          <span>
             Scope
-            <span class="tooltip tooptip-left">number of relationship hops away from focused entity</span>
+            <span #ttt3 class="tooltip-text">number of relationship hops away from focused entity</span>
           </span>
           <span class="left-adjusted"><mat-checkbox class="unpadded" [checked]="unlimitedMaxScope" (change)="onMaxUnlimitedChange('unlimitedMaxScope',$event.checked)">unlimited</mat-checkbox></span>
         </div>
@@ -54,12 +59,12 @@
         <span class="intVal">({{ buildOut }})</span>
       </label>
     </li>
-    <li class="has-tooltip block-level-src no-text-selection" *ngIf="showMaxEntities">
+    <li class="block-level-src no-text-selection" *ngIf="showMaxEntities" (mouseenter)="onShowTooltip(ttt4.innerHTML, $event)" (mouseleave)="hideTooltip(ttt4.innerHTML)">
       <label class="checkbox-row">
         <div class="checkbox-row">
-          <span class="has-tooltip">
+          <span>
             Max
-            <span class="tooltip tooptip-left">hard limit on how many entities will be displayed</span>
+            <span #ttt4 class="tooltip-text">hard limit on how many entities will be displayed</span>
           </span>
           <span class="left-adjusted"><mat-checkbox class="unpadded" [checked]="unlimitedMaxEntities" (change)="onMaxUnlimitedChange('unlimitedMaxEntities',$event.checked)">unlimited</mat-checkbox></span>
         </div>
@@ -76,12 +81,12 @@
         <span style="white-space: nowrap;">({{ maxEntitiesValueLabel }}) of {{ maxEntitiesLimit }}</span>
       </label>
     </li>
-    <li *ngIf="showMaxDegreesOfSeparation">
+    <li *ngIf="showMaxDegreesOfSeparation" (mouseenter)="onShowTooltip(ttt5.innerHTML, $event)" (mouseleave)="hideTooltip(ttt5.innerHTML)">
       <label>
         <div>
-          <span class="has-tooltip">
+          <span>
             Degrees
-            <span class="tooltip tooptip-left">maximum degrees of separation between nodes and focus</span>
+            <span #ttt5 class="tooltip-text">maximum degrees of separation between nodes and focus</span>
           </span>
         </div>
         <input type="range" min="1" max="5" [value]="maxDegreesOfSeparation" formControlName="maxDegreesOfSeparation" 
@@ -93,7 +98,7 @@
   </form>
 
   <hr>
-  <h3>{{ sectionTitles[1] }}</h3>
+  <h3 (mouseenter)="onShowTooltip('Only display entities that are in the selected datasource(s)', $event)" (mouseleave)="hideTooltip()">{{ sectionTitles[1] }}</h3>
   <form [formGroup]="filterByDataSourcesForm">
   <ul class="filters-list">
     <ng-container *ngFor="let ds of filterByDataSourcesData.controls; let i = index">
@@ -111,14 +116,14 @@
   <hr>
   <h3>{{ sectionTitles[2] }}</h3>
   <ul class="colors-list">
-    <li class="color-box">
+    <li class="color-box" (mouseenter)="onShowTooltip('select color(s) for relationship lines that are directly related to the focal entity', $event)" (mouseleave)="hideTooltip()">
       <div class="color-box-placeholder"></div>
       <label>
         <input type="color" [(ngModel)]="linkColor" [style.background-color]="linkColor" (change)="onColorParameterChange('linkColor', getValueFromEventTarget($event))">
         Directly Related
       </label>
     </li>
-    <li class="color-box">
+    <li class="color-box" (mouseenter)="onShowTooltip('select color(s) for relationship lines that are not directly related to the focal entity', $event)" (mouseleave)="hideTooltip()">
       <div class="color-box-placeholder"></div>
       <label>
         <input type="color" [(ngModel)]="indirectLinkColor" [style.background-color]="indirectLinkColor" (change)="onColorParameterChange('indirectLinkColor', getValueFromEventTarget($event))">
@@ -128,7 +133,7 @@
   </ul>
 
   <hr>
-  <h3>{{ sectionTitles[3] }}</h3>
+  <h3 (mouseenter)="onShowTooltip('select color(s) for entities that are present in selected datasource(s)', $event)" (mouseleave)="hideTooltip()">{{ sectionTitles[3] }}</h3>
   <ul cdkDropList class="colors-list" (cdkDropListDropped)="onColorOrderDrop($event)">
     <ng-container *ngFor="let ds of dataSourceColors; let i = index">
       <li class="color-box" *ngIf="shouldDataSourceBeDisplayed(ds.name)" cdkDrag [cdkDragData]="ds.name">
@@ -148,13 +153,13 @@
   <h3>{{ sectionTitles[4] }}</h3>
   <form [formGroup]="colorsMiscForm">
   <ul class="other-colors-list">
-    <li>
+    <li (mouseenter)="onShowTooltip(ttt6.innerHTML, $event)" (mouseleave)="hideTooltip()">
       <label>
         <input #queriedNodesColorInput formControlName="queriedEntitiesColor" type="color" [style.background-color]="queriedNodesColorInput.value" 
           (change)="onColorParameterChange('queriedEntitiesColor', getValueFromEventTarget($event))">
-        <span class="has-tooltip block-level-src">
+        <span class="block-level-src">
           Active/Focused Enitity
-          <span class="tooltip tooptip-left">The color of the current entity or entities</span>
+          <span #ttt6 class="tooltip-text">The color of the current entity or entities</span>
         </span>
         <small class="note-sub">(*note overrides datasource member color if selected)</small>
       </label>

--- a/src/lib/graph/sz-graph-filter.component.html
+++ b/src/lib/graph/sz-graph-filter.component.html
@@ -133,7 +133,7 @@
   </ul>
 
   <hr>
-  <h3 (mouseenter)="onShowTooltip('select color(s) for entities that are present in selected datasource(s)', $event)" (mouseleave)="hideTooltip()">{{ sectionTitles[3] }}</h3>
+  <h3 class="no-text-selection" (mouseover)="onShowTooltip('select color(s) for entities that are present in selected datasource(s)', $event)" (mouseout)="hideTooltip('select color(s) for entities that are present in selected datasource(s)')">{{ sectionTitles[3] }}</h3>
   <ul cdkDropList class="colors-list" (cdkDropListDropped)="onColorOrderDrop($event)">
     <ng-container *ngFor="let ds of dataSourceColors; let i = index">
       <li class="color-box" *ngIf="shouldDataSourceBeDisplayed(ds.name)" cdkDrag [cdkDragData]="ds.name">
@@ -153,7 +153,7 @@
   <h3>{{ sectionTitles[4] }}</h3>
   <form [formGroup]="colorsMiscForm">
   <ul class="other-colors-list">
-    <li (mouseenter)="onShowTooltip(ttt6.innerHTML, $event)" (mouseleave)="hideTooltip()">
+    <li class="no-text-selection" (mouseover)="onShowTooltip(ttt6.innerHTML, $event)" (mouseout)="hideTooltip(ttt6.innerHTML)">
       <label>
         <input #queriedNodesColorInput formControlName="queriedEntitiesColor" type="color" [style.background-color]="queriedNodesColorInput.value" 
           (change)="onColorParameterChange('queriedEntitiesColor', getValueFromEventTarget($event))">

--- a/src/lib/graph/sz-graph-filter.component.scss
+++ b/src/lib/graph/sz-graph-filter.component.scss
@@ -250,47 +250,8 @@
   @include no-text-selection;
 }
 
-.has-tooltip {
-  position: relative;
-  .tooltip {
-    position: absolute;
-    visibility: hidden;
-    opacity: 0;
-    right: -100%;
-    bottom: 115%;
-    /* width: 120px; */
-    background-color: #00000073;
-    color: #fff;
-    text-align: center;
-    padding: 5px 8px;
-    border-radius: 6px;
-    white-space: nowrap;
-    font-size: 10px;
-    z-index: 1;
-    transition: opacity .5s;
-  }
-  &.block-level-src {
-    .tooltip {
-      right: 10%;
-    }
-  }
-  /* tooltip has little pointer nub */
-  .tooltip::after {
-    content: "";
-    position: absolute;
-    top: 100%;
-    left: 80%;
-    margin-left: -5px;
-    border-width: 5px;
-    border-style: solid;
-    border-color: #00000073 transparent transparent transparent;
-  }
-}
-
-/* Show the tooltip text when you mouse over the tooltip container */
-.has-tooltip:hover .tooltip {
-  visibility: visible;
-  opacity: 1;
+.tooltip-text {
+  display: none;
 }
 
 .cdk-drag-preview {

--- a/src/lib/graph/sz-graph-filter.component.ts
+++ b/src/lib/graph/sz-graph-filter.component.ts
@@ -550,10 +550,17 @@ export class SzGraphFilterComponent implements OnInit, AfterViewInit, OnDestroy 
       return false;
     }
     if (this.overlayRef) {
-      this.overlayRef.dispose();
-      this.overlayRef = undefined;
+      this.overlayRef.addPanelClass('fade-out');
+      // we want to give the animation time to finish 
+      // before fading out
+      setTimeout(() => {
+        if (this.overlayRef) {
+          this.overlayRef.dispose();
+          this.overlayRef = undefined;
+        }
+        this._tooltipLastMessageShown = undefined;
+      }, 150)
     }
-    this._tooltipLastMessageShown = undefined;
     return false;
   }
 

--- a/src/lib/graph/sz-graph-filter.component.ts
+++ b/src/lib/graph/sz-graph-filter.component.ts
@@ -1,12 +1,16 @@
-import { Component, HostBinding, Input, OnInit, AfterViewInit, OnDestroy, Output, EventEmitter, ChangeDetectorRef } from '@angular/core';
+import { Component, HostBinding, Input, OnInit, AfterViewInit, 
+  OnDestroy, Output, EventEmitter, ChangeDetectorRef, ViewChild, TemplateRef, 
+  ViewContainerRef } from '@angular/core';
 import { SzPrefsService, SzSdkPrefsModel } from '../services/sz-prefs.service';
 import { SzDataSourcesService } from '../services/sz-datasources.service';
 import { takeUntil } from 'rxjs/operators';
-import { BehaviorSubject, Subject } from 'rxjs';
+import { Subject } from 'rxjs';
 import { UntypedFormBuilder, UntypedFormGroup, UntypedFormArray, UntypedFormControl, Validators } from '@angular/forms';
 import { CdkDragDrop, moveItemInArray } from '@angular/cdk/drag-drop';
+import { Overlay, OverlayRef } from '@angular/cdk/overlay';
+import { TemplatePortal } from '@angular/cdk/portal';
 import { SzDataSourceComposite } from '../models/data-sources';
-import { SzMatchKeyComposite, SzMatchKeyTokenComposite, SzEntityNetworkMatchKeyTokens, SzMatchKeyTokenFilterScope } from '../models/graph';
+import { SzMatchKeyComposite, SzMatchKeyTokenComposite, SzMatchKeyTokenFilterScope } from '../models/graph';
 import { sortDataSourcesByIndex, parseBool, sortMatchKeysByIndex, sortMatchKeyTokensByIndex } from '../common/utils';
 import { isBoolean } from '../common/utils';
 
@@ -37,6 +41,11 @@ import { isBoolean } from '../common/utils';
   styleUrls: ['./sz-graph-filter.component.scss']
 })
 export class SzGraphFilterComponent implements OnInit, AfterViewInit, OnDestroy {
+  /**
+   * used for displaying tooltips above all other page content 
+   * @internal */
+  overlayRef: OverlayRef | undefined;
+
   isOpen: boolean = true;
   /** subscription to notify subscribers to unbind */
   public unsubscribe$ = new Subject<void>();
@@ -46,6 +55,18 @@ export class SzGraphFilterComponent implements OnInit, AfterViewInit, OnDestroy 
   private _dataSources: SzDataSourceComposite[]               = [];
   private _matchKeys: SzMatchKeyComposite[]                   = [];
   private _matchKeyTokens: SzMatchKeyTokenComposite[]         = [];
+
+  // ----------- tooltip related
+  /** @internal */
+  @ViewChild('tooltip') tooltip: TemplateRef<any>;
+  /** @internal */
+  private _tooltipSubCloseTimer;
+  /** @internal */
+  private _tooltipElapsedTimer;
+  /** @internal */
+  private _tooltipLastMessageShown: string;
+  /** @internal */
+  private _tooltipElapsedTime: number;
 
   /** private list of SzDataSourceComposite as stored in local storage 
    * @internal
@@ -353,7 +374,9 @@ export class SzGraphFilterComponent implements OnInit, AfterViewInit, OnDestroy 
     public prefs: SzPrefsService,
     public dataSourcesService: SzDataSourcesService,
     private formBuilder: UntypedFormBuilder,
-    private cd: ChangeDetectorRef
+    private cd: ChangeDetectorRef,
+    public overlay: Overlay,
+    public viewContainerRef: ViewContainerRef,
   ) {
     // ----- initialize form control groups ------
     // sliders
@@ -463,6 +486,81 @@ export class SzGraphFilterComponent implements OnInit, AfterViewInit, OnDestroy 
       console.log(`@senzing/sdk-components-ng/sz-entity-detail-graph-filter.onCoreMkTagFilterToggle: added ${mkName} to cloud value`,_matchKeyTokensIncludedMemCopy, this.matchKeyCoreTokensIncluded);
     }
   }
+
+  /**
+   * display a new tooltip using the template portal
+   * @internal
+   */
+  onShowTooltip(message: string, event: any) {
+    // extend event object to we can pass
+    //event = Object.assign(event, {tooltip: message});
+    let messageAlreadyShowing = this._tooltipLastMessageShown && this._tooltipLastMessageShown == message ? true : false;
+
+    // if message is different immediately close last tooltip
+    if(!messageAlreadyShowing) {
+      this.hideTooltip();
+    }
+    // store new value
+    this._tooltipLastMessageShown = message;
+    // update close timer if set
+
+    if(this._tooltipSubCloseTimer) {
+      // timer already exists, just adding time to it
+      clearTimeout(this._tooltipSubCloseTimer);
+    }
+    this._tooltipSubCloseTimer  = setTimeout(this.hideTooltip.bind(this), 2000);
+    if(!this._tooltipElapsedTimer){
+      // we want to count how much time is passed while tooltip is being displayed
+      // so we can prevent rapid flickering on mousemove
+      this._tooltipElapsedTimer   = setInterval(() => this._tooltipElapsedTime = this._tooltipElapsedTime+500,500);
+    }
+
+    if(messageAlreadyShowing || this.overlayRef) {
+      // if message already showing no need to create new overlay
+      // this.overlayRef should be undefined if old overlay cleared out
+      return false;
+    }
+
+    //let scrollY = document.documentElement.scrollTop || document.body.scrollTop;
+    const positionStrategy = this.overlay.position().global();
+    //positionStrategy.top(Math.ceil(event.eventPageY - scrollY)+'px');
+    //positionStrategy.left(Math.ceil(event.eventPageX)+'px');
+    positionStrategy.top(Math.ceil(event.y)+'px');
+    positionStrategy.left(Math.ceil(event.x)+'px');
+
+    this.overlayRef = this.overlay.create({
+      positionStrategy,
+      scrollStrategy: this.overlay.scrollStrategies.close()
+    });
+
+    this.overlayRef.attach(new TemplatePortal(this.tooltip, this.viewContainerRef, {
+      $implicit: message
+    }));
+
+    return false;
+  }
+
+  /**
+   * hides visible tooltip 
+   * @internal 
+   */
+  hideTooltip(message?: string) {
+    if(message && this._tooltipLastMessageShown && message === this._tooltipLastMessageShown && this._tooltipElapsedTime < 1000) {
+      // this is the exact same message being currently displayed
+      // we care if there has been a minimum amount of time displayed (to avoid flicker)
+      return;
+    }
+    if (this.overlayRef) {
+      this.overlayRef.dispose();
+      this.overlayRef = undefined;
+    }
+    if( this._tooltipElapsedTimer ){
+      clearInterval(this._tooltipElapsedTimer);
+    }
+    this._tooltipLastMessageShown = undefined;
+    this._tooltipElapsedTime      = undefined;
+  }
+
   /**
    * method for getting the selected pref color for a datasource 
    * by the datasource name. used for applying background color to 

--- a/src/lib/graph/sz-graph.component.ts
+++ b/src/lib/graph/sz-graph.component.ts
@@ -259,15 +259,16 @@ export class SzGraphComponent implements OnInit, OnDestroy {
   public filterShowDataSources: string[];
   public filterShowMatchKeys: string[];
   public filterShowMatchKeyTokens: Array<SzMatchKeyTokenComposite>;
-  private _showMatchKeysFilters: boolean = true;
-  private _showMatchKeyTokenFilters: boolean = false;
-  private _showMatchKeyControl: boolean = true;
+  private _showMatchKeysFilters: boolean      = true;
+  private _showMatchKeyTokenFilters: boolean  = false;
+  private _showMatchKeyControl: boolean       = true;
+  private _showFilterTooltips: boolean        = true;
 
   /** whether or not to show the [ALL] | [NONE] macro token actions button */
   @Input() public showMatchKeyTokenSelectAll: boolean       = true;
 
   /** @internal */
-  protected _showCoreMatchKeyTokenChips: boolean              = false;
+  protected _showCoreMatchKeyTokenChips: boolean            = false;
   /**
    * whether or not to show only the match key token chips that apply 
    * to "core" relationships. ie if the relationship is only between 
@@ -364,6 +365,12 @@ export class SzGraphComponent implements OnInit, OnDestroy {
   get showMatchKeyTokenFilters(): boolean | string {
     return this._showMatchKeyTokenFilters;
   }
+  @Input() set showFilterTooltips(value: boolean | string) {
+    this._showFilterTooltips = parseBool(value);    
+  }
+  get showFilterTooltips(): boolean | string {
+    return this._showFilterTooltips;
+  } 
 
   private _showZoomControl: boolean = true;
   /** the whether or not the zoom control is shown */

--- a/src/lib/scss/styles.scss
+++ b/src/lib/scss/styles.scss
@@ -214,19 +214,16 @@ mat-chip-listbox.match-keys {
 .cdk-overlay-pane {
   .sz-sdk-tooltip {
     position: relative;
-    /*visibility: hidden;*/
     opacity: 1;
     left: -80%;
-    bottom: 60px;
-    /* width: 120px; */
-    background-color: #000000a6;
-    color: #fff;
+    background-color: var(--sz-graph-filter-tooltip-background-color);
+    color: var(--sz-graph-filter-tooltip-color);
     text-align: center;
-    padding: 10px 16px;
-    border-radius: 6px;
+    padding: var(--sz-graph-filter-tooltip-padding);
+    border-radius: var(--sz-graph-filter-tooltip-border-radius);
     white-space: nowrap;
-    font-size: 10px;
-    z-index: 1;
+    font-size: var(--sz-graph-filter-tooltip-font-size);
+    z-index: var(--sz-graph-filter-tooltip-z-index);
     transition: opacity 500ms;
   }
   /* tooltip has little pointer nub */
@@ -234,11 +231,11 @@ mat-chip-listbox.match-keys {
     content: "";
     position: absolute;
     top: 100%;
-    left: 80%;
+    left: calc(80% - 20px);
     margin-left: -5px;
     border-width: 5px;
     border-style: solid;
-    border-color: #000000a6 transparent transparent transparent;
+    border-color: var(--sz-graph-filter-tooltip-background-color) transparent transparent transparent;
   }
   &.fade-out {
     .sz-sdk-tooltip {

--- a/src/lib/scss/styles.scss
+++ b/src/lib/scss/styles.scss
@@ -210,6 +210,42 @@ mat-chip-listbox.match-keys {
   }
 }
 
+/* graph tooltips */
+.cdk-overlay-pane {
+  .sz-sdk-tooltip {
+    position: relative;
+    /*visibility: hidden;*/
+    opacity: 1;
+    left: -80%;
+    bottom: 60px;
+    /* width: 120px; */
+    background-color: #000000a6;
+    color: #fff;
+    text-align: center;
+    padding: 10px 16px;
+    border-radius: 6px;
+    white-space: nowrap;
+    font-size: 10px;
+    z-index: 1;
+    transition: opacity 500ms;
+  }
+  /* tooltip has little pointer nub */
+  .sz-sdk-tooltip::after {
+    content: "";
+    position: absolute;
+    top: 100%;
+    left: 80%;
+    margin-left: -5px;
+    border-width: 5px;
+    border-style: solid;
+    border-color: #000000a6 transparent transparent transparent;
+  }
+  &.fade-out {
+    .sz-sdk-tooltip {
+      opacity: 0;
+    }
+  }
+}
 
 .senzing-alarm:before {
   content: "\e900";

--- a/src/lib/scss/styles.scss
+++ b/src/lib/scss/styles.scss
@@ -224,7 +224,7 @@ mat-chip-listbox.match-keys {
     white-space: nowrap;
     font-size: var(--sz-graph-filter-tooltip-font-size);
     z-index: var(--sz-graph-filter-tooltip-z-index);
-    transition: opacity 500ms;
+    transition: opacity 100ms;
   }
   /* tooltip has little pointer nub */
   .sz-sdk-tooltip::after {

--- a/src/lib/scss/theme.scss
+++ b/src/lib/scss/theme.scss
@@ -400,7 +400,13 @@ body {
     --sz-graph-filter-match-key-mode-select-handle-color: rgb(219, 219, 219);
     --sz-graph-filter-match-key-mode-select-active-track-color: rgba(15, 158, 247, 0.31);
     --sz-graph-filter-match-key-mode-select-active-handle-color: #{$sz-blue};
-
+    /* filter tooltips */
+    --sz-graph-filter-tooltip-background-color: #353535a6;
+    --sz-graph-filter-tooltip-color: #fff;
+    --sz-graph-filter-tooltip-padding: 10px 16px;
+    --sz-graph-filter-tooltip-border-radius: 6px;
+    --sz-graph-filter-tooltip-font-size: 10px;
+    --sz-graph-filter-tooltip-z-index: 1;
   /* end entity detail vars */
   /* start preferences component */
     --sz-preferences-column-border-radius: 5px;

--- a/src/package.json
+++ b/src/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@senzing/sdk-components-ng",
-  "version": "6.0.0",
+  "version": "6.0.1",
   "private": false,
   "keywords" :["Angular","Library","Senzing"],
   "license" : "SEE LICENSE IN LICENSE",


### PR DESCRIPTION
# Pull request questions

## Which issue does this address

resolves #437 

## Why was change needed

tooltips were nested inside a scroll container with `overflow: hidden` set which was clipping them.
![image](https://user-images.githubusercontent.com/13721038/229962392-be25f304-b087-49dc-bfe2-77cff36984ce.png)
![image](https://user-images.githubusercontent.com/13721038/229962514-8af65009-dc65-4782-8340-fe112a01a838.png)


## What does change improve

tooltips are now dynamically created at the top level of the dom instead of inside the toolbar container.
