### PR TITLE
#496 match keys turned on by default

### DIFF
--- a/src/lib/entity/sz-entity-record-card/sz-entity-record-card-content/sz-entity-record-card-content.component.ts
+++ b/src/lib/entity/sz-entity-record-card/sz-entity-record-card-content/sz-entity-record-card-content.component.ts
@@ -40,7 +40,7 @@ export class SzEntityRecordCardContentComponent implements OnInit {
   @Input() public whySelectionAction: SzWhySelectionActionBehavior = SzWhySelectionAction.NONE;
 
   @Input() public showWhyUtilities: boolean = false;
-  @Input() public showRecordIdWhenNative: boolean = false;
+  @Input() public showRecordIdWhenNative: boolean = true;
   /** allows records with empty columns to match up with records with non-empty columns. format is [true,false,true,true,true] */
   @Input() public columnsShown: boolean[] = undefined;
   @Input() public set ignorePrefOtherDataChanges(value: boolean) {

--- a/src/lib/graph/sz-graph-filter.component.spec.ts
+++ b/src/lib/graph/sz-graph-filter.component.spec.ts
@@ -33,6 +33,6 @@ describe('SzGraphFilterComponent', () => {
   });
   // labels hidden by default
   it('graph should default to hide link labels', () => {
-    expect(component.showLinkLabels).toBeFalsy();
+    expect(component.showLinkLabels).toBeTruthy();
   });
 });

--- a/src/lib/graph/sz-graph-filter.component.spec.ts
+++ b/src/lib/graph/sz-graph-filter.component.spec.ts
@@ -32,7 +32,7 @@ describe('SzGraphFilterComponent', () => {
     expect(component.isOpen).toBeTruthy();
   });
   // labels hidden by default
-  it('graph should default to hide link labels', () => {
+  it('graph should default to show link labels', () => {
     expect(component.showLinkLabels).toBeTruthy();
   });
 });

--- a/src/lib/graph/sz-graph.component.ts
+++ b/src/lib/graph/sz-graph.component.ts
@@ -84,7 +84,7 @@ export class SzGraphComponent implements OnInit, OnDestroy {
     relatedEntities: SzRelatedEntity[]
   }*/
   /** @internal */
-  public _showLinkLabels = false;
+  public _showLinkLabels = true;
   /** sets the visibility of edge labels on the node links */
   @Input() public set showLinkLabels(value: boolean | string) {
     this._showLinkLabels = parseBool(value);

--- a/src/lib/services/sz-prefs.service.ts
+++ b/src/lib/services/sz-prefs.service.ts
@@ -857,7 +857,7 @@ export class SzGraphPrefs extends SzSdkPrefsBase {
   /** @internal */
   private _dataSourceColors: SzDataSourceComposite[] = [];
   /** @internal */
-  private _showLinkLabels: boolean = false;
+  private _showLinkLabels: boolean = true;
   /** @internal */
   private _rememberStateOptions: boolean = true;
   /** @internal */

--- a/src/lib/services/sz-prefs.service.ts
+++ b/src/lib/services/sz-prefs.service.ts
@@ -588,7 +588,7 @@ export class SzEntityDetailPrefs extends SzSdkPrefsBase {
   /** @internal */
   private _hideGraphWhenZeroRelations: boolean = true;
   /** @internal */
-  private _showRecordIdWhenNative: boolean = false;
+  private _showRecordIdWhenNative: boolean = true;
   /** @internal */
   private _showTopEntityRecordIdsWhenSingular: boolean = false;
 


### PR DESCRIPTION
# Pull request questions

## Which issue does this address

resolves #496 

## Why was change needed

turn match keys in graph _on_ by default
