### PR TITLE
bugfix for how/why/why not

### DIFF
--- a/src/lib/sdk.module.ts
+++ b/src/lib/sdk.module.ts
@@ -76,6 +76,7 @@ import { SzWhyEntityComponent } from './why/sz-why-entity.component';
 import { SzWhyEntitiesComparisonComponent } from './why/sz-why-entities.component';
 import { SzWhyEntityDialog } from './why/sz-why-entity.component';
 import { SzWhyEntitiesDialog } from './why/sz-why-entities.component';
+import { SzWhyReportBaseComponent } from './why/sz-why-report-base.component';
 // how related
 import { SzHowEntityComponent } from './how/sz-how-entity.component';
 import { SzHowFinalEntityCardComponent } from './how/cards/sz-how-final-entity-card.component';
@@ -163,7 +164,8 @@ const SzRestConfigurationInjector = new InjectionToken<SzRestConfiguration>("SzR
         SzWhyEntitiesComparisonComponent,
         SzWhyEntityComponent,
         SzWhyEntitiesDialog,
-        SzWhyEntityDialog
+        SzWhyEntityDialog,
+        SzWhyReportBaseComponent
     ],
     imports: [
         CommonModule,

--- a/src/lib/services/sz-config-data.service.ts
+++ b/src/lib/services/sz-config-data.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core';
-import { Observable, Subject } from 'rxjs';
+import { Observable, Subject, throwError } from 'rxjs';
 
 import {
     ConfigService as SzConfigService, SzConfigResponse,
@@ -63,14 +63,20 @@ export class SzConfigDataService {
                     _retVal.next(v); 
                 }).bind(this, this._orderedFeatureTypes), 500);
         } else {
-            this.getActiveConfig().subscribe((res: any)=>{
-                let fTypes = this.getFeaturesFromConfig(res)
-                let assocFtypes = fTypes.map((feat: any) => {
-                    return feat.FTYPE_CODE;
-                });
-                this._orderedFeatureTypes = assocFtypes;
-                _retVal.next(assocFtypes);
-                console.log('getOrderedFeatures: ', assocFtypes);
+            this.getActiveConfig().subscribe({
+                next: (res: any)=>{
+                    let fTypes = this.getFeaturesFromConfig(res)
+                    let assocFtypes = fTypes.map((feat: any) => {
+                        return feat.FTYPE_CODE;
+                    });
+                    this._orderedFeatureTypes = assocFtypes;
+                    _retVal.next(assocFtypes);
+                    console.log('getOrderedFeatures: ', assocFtypes);
+                },
+                error: (err) => {
+                    console.warn('could not get active config: ', err);
+                    _retVal.error(err);
+                }
             });
         }
         return retVal;

--- a/src/lib/why/sz-why-entities.component.ts
+++ b/src/lib/why/sz-why-entities.component.ts
@@ -1,19 +1,13 @@
-import { Component, OnInit, Input, Inject, OnDestroy, Output, EventEmitter, ViewChild, HostBinding, ElementRef, NgZone, AfterViewInit } from '@angular/core';
+import { Component, OnInit, Input, Inject, OnDestroy, Output, EventEmitter, ViewChild, HostBinding } from '@angular/core';
 import { MAT_DIALOG_DATA } from '@angular/material/dialog';
-import { DataSource } from '@angular/cdk/collections';
-import { EntityDataService, SzCandidateKey, SzDataSourceRecordSummary, SzDetailLevel, SzEntityData, SzEntityFeature, SzEntityFeatureDetail, SzEntityIdentifier, SzFeatureMode, SzFeatureScore, SzFocusRecordId, SzRecordId, SzWhyEntitiesResponse, SzWhyEntitiesResponseData, SzWhyEntitiesResult, SzWhyEntityResponseData } from '@senzing/rest-api-client-ng';
-import { BehaviorSubject, Observable, ReplaySubject, Subject, takeUntil, throwError, zip } from 'rxjs';
-import { debounceTime, filter } from "rxjs/operators";
+import { EntityDataService, SzCandidateKey, SzDetailLevel, SzEntityData, SzEntityFeature, SzEntityFeatureDetail, SzEntityIdentifier, SzFeatureMode, SzFeatureScore, SzFocusRecordId, SzWhyEntitiesResponse, SzWhyEntitiesResult } from '@senzing/rest-api-client-ng';
+import { Observable, Subject, takeUntil, throwError, zip } from 'rxjs';
 
-import { getMapFromMatchKey, parseSzIdentifier } from '../common/utils';
-import { SzPrefsService } from '../services/sz-prefs.service';
+import { getMapFromMatchKey } from '../common/utils';
 import { SzConfigDataService } from '../services/sz-config-data.service';
-import { SzWhyEntityComponent } from './sz-why-entity.component';
 import { SzEntityFeatureWithScoring, SzWhyEntityColumn, SzWhyEntityHTMLFragment, SzWhyFeatureRow } from '../models/data-why';
 import { SzWhyReportBaseComponent } from './sz-why-report-base.component';
-import * as e from 'express';
 import { SzCSSClassService } from '../services/sz-css-class.service';
-import { HttpEvent } from '@angular/common/http';
 
 /**
  * Display the "Why" information for entities

--- a/src/lib/why/sz-why-entity.component.ts
+++ b/src/lib/why/sz-why-entity.component.ts
@@ -48,7 +48,7 @@ export class SzWhyEntityComponent extends SzWhyReportBaseComponent implements On
         takeUntil(this.unsubscribe$)
     ).subscribe({
         next: this.onDataResponse,
-        error: (err, params?) => {
+        error: (err) => {
             this._isLoading = false;
             if(err && err.url && err.url.indexOf && err.url.indexOf('configs/active') > -1) {
                 // ok, we're going to try one more time without the active config
@@ -60,36 +60,6 @@ export class SzWhyEntityComponent extends SzWhyReportBaseComponent implements On
                 })
             }
         }
-    });
-
-    zip(
-      this.getData(),
-      this.getOrderedFeatures()
-    ).subscribe({
-      next: (results) => {
-        this._isLoading = false;
-        this.loading.emit(false);
-        this._data          = results[0].data.whyResults;
-        this._entities      = results[0].data.entities;
-        // add any fields defined in initial _rows value to the beginning of the order
-        // custom/meta fields go first basically
-        this._orderedFeatureTypes = this._rows.map((fr)=>{ return fr.key}).concat(results[1]);
-        this._featureStatsById  = this.getFeatureStatsByIdFromEntityData(this._entities);
-        //console.log(`SzWhyEntityComponent._featureStatsById: `, this._featureStatsById);
-
-        this._shapedData    = this.transformData(this._data, this._entities);
-        this._formattedData = this.formatData(this._shapedData);
-        // now that we have all our "results" grab the features so we 
-        // can iterate by those and blank out cells that are missing
-        this._rows          = this.getRowsFromData(this._shapedData, this._orderedFeatureTypes);
-        this._headers       = this.getHeadersFromData(this._shapedData);
-        //console.warn('SzWhyEntityComponent.getWhyData: ', results, this._rows, this._shapedData);
-        this.onResult.emit(this._data);
-        this.onRowsChanged.emit(this._rows);
-      },
-      error: (err) => {
-        console.error(err);
-      }
     });
   }
 
@@ -123,7 +93,9 @@ export class SzWhyEntityComponent extends SzWhyReportBaseComponent implements On
     // can iterate by those and blank out cells that are missing
     this._rows          = this.getRowsFromData(this._shapedData, this._orderedFeatureTypes);
     this._headers       = this.getHeadersFromData(this._shapedData);
-    this.onResult.next(this._shapedData);
+    //console.warn('SzWhyEntityComponent.getWhyData: ', results, this._rows, this._shapedData);
+    this.onResult.emit(this._data);
+    this.onRowsChanged.emit(this._rows);
   }
   /**
    * Extends the data response from the why api with data found "rows" that can be more directly utilized by the rendering template.

--- a/src/lib/why/sz-why-report-base.component.ts
+++ b/src/lib/why/sz-why-report-base.component.ts
@@ -303,7 +303,6 @@ export class SzWhyReportBaseComponent implements OnInit, OnDestroy {
     ngOnInit() {
       this._isLoading = true;
       this.loading.emit(true);
-      
       zip(
         this.getData(),
         this.getOrderedFeatures()
@@ -311,7 +310,7 @@ export class SzWhyReportBaseComponent implements OnInit, OnDestroy {
           takeUntil(this.unsubscribe$)
       ).subscribe({
           next: this.onDataResponse,
-          error: (err, params?) => {
+          error: (err) => {
               this._isLoading = false;
               if(err && err.url && err.url.indexOf && err.url.indexOf('configs/active') > -1) {
                   // ok, we're going to try one more time without the active config

--- a/src/lib/why/sz-why-report-base.component.ts
+++ b/src/lib/why/sz-why-report-base.component.ts
@@ -1,6 +1,6 @@
 import { Component, OnInit, Input, OnDestroy, Output, EventEmitter } from '@angular/core';
-import { EntityDataService, SzCandidateKey, SzDetailLevel, SzEntityData, SzEntityFeature, SzEntityFeatureDetail, SzEntityIdentifier, SzFeatureMode, SzFeatureScore, SzFocusRecordId, SzMatchedRecord, SzRecordId, SzWhyEntitiesResult, SzWhyEntityResult } from '@senzing/rest-api-client-ng';
-import { Subject, zip } from 'rxjs';
+import { EntityDataService, SzCandidateKey, SzDetailLevel, SzEntityData, SzEntityFeature, SzEntityFeatureDetail, SzEntityIdentifier, SzFeatureMode, SzFeatureScore, SzFocusRecordId, SzMatchedRecord, SzRecordId, SzWhyEntitiesResult, SzWhyEntityResponse, SzWhyEntityResult } from '@senzing/rest-api-client-ng';
+import { Observable, Subject, takeUntil, zip } from 'rxjs';
 import { getArrayOfPairsFromMatchKey, parseSzIdentifier } from '../common/utils';
 import { SzConfigDataService } from '../services/sz-config-data.service';
 import { SzWhyEntityColumn, SzWhyEntityHTMLFragment, SzWhyFeatureRow } from '../models/data-why';
@@ -303,35 +303,26 @@ export class SzWhyReportBaseComponent implements OnInit, OnDestroy {
     ngOnInit() {
       this._isLoading = true;
       this.loading.emit(true);
-  
+      
       zip(
-        this.getWhyData(),
+        this.getData(),
         this.getOrderedFeatures()
+      ).pipe(
+          takeUntil(this.unsubscribe$)
       ).subscribe({
-        next: (results) => {
-          this._isLoading = false;
-          this.loading.emit(false);
-          this._data          = results[0].data.whyResults;
-          this._entities      = results[0].data.entities;
-          // add any fields defined in initial _rows value to the beginning of the order
-          // custom/meta fields go first basically
-          this._orderedFeatureTypes = this._rows.map((fr)=>{ return fr.key}).concat(results[1]);
-          this._featureStatsById  = this.getFeatureStatsByIdFromEntityData(this._entities);
-          //console.log(`SzWhyEntityComponent._featureStatsById: `, this._featureStatsById);
-  
-          this._shapedData    = this.transformData(this._data, this._entities);
-          this._formattedData = this.formatData(this._shapedData);
-          // now that we have all our "results" grab the features so we 
-          // can iterate by those and blank out cells that are missing
-          this._rows          = this.getRowsFromData(this._shapedData, this._orderedFeatureTypes);
-          this._headers       = this.getHeadersFromData(this._shapedData);
-          //console.warn('SzWhyEntityComponent.getWhyData: ', results, this._rows, this._shapedData);
-          //this.onResult.emit(this._data);
-          //this.onRowsChanged.emit(this._rows);
-        },
-        error: (err) => {
-          console.error(err);
-        }
+          next: this.onDataResponse,
+          error: (err, params?) => {
+              this._isLoading = false;
+              if(err && err.url && err.url.indexOf && err.url.indexOf('configs/active') > -1) {
+                  // ok, we're going to try one more time without the active config
+                  this._isLoading = true;
+                  this.getData().pipe(
+                      takeUntil(this.unsubscribe$)
+                  ).subscribe((res) => {
+                      this.onDataResponse([res, undefined]);
+                  })
+              }
+          }
       });
     }
     /**
@@ -345,7 +336,7 @@ export class SzWhyReportBaseComponent implements OnInit, OnDestroy {
     // --------------------------- data manipulation subs and routines ---------------------------
   
     /** call the /why api endpoint and return a observeable */
-    protected getWhyData() {
+    protected getData(): Observable<SzWhyEntityResponse> {
       return this.entityData.whyEntityByEntityID(parseSzIdentifier(this.entityId), true, true, true, SzDetailLevel.VERBOSE, SzFeatureMode.REPRESENTATIVE, false, false)
     }
     /** get the features in the order found in the server config */
@@ -493,6 +484,31 @@ export class SzWhyReportBaseComponent implements OnInit, OnDestroy {
         });
       }
       return retVal;
+    }
+    /**
+     * when the api requests respond this method properly sets up all the 
+     * properties that get set/generated from some part of those requests
+     * @interal
+     */
+    protected onDataResponse(results: [SzWhyEntityResponse, string[]]) {
+      this._isLoading = false;
+      this.loading.emit(false);
+      this._data          = results[0].data.whyResults;
+      this._entities      = results[0].data.entities;
+      // add any fields defined in initial _rows value to the beginning of the order
+      // custom/meta fields go first basically
+      if(results[1]){ 
+        this._orderedFeatureTypes = this._rows.map((fr)=>{ return fr.key}).concat(results[1]);
+      }
+      this._featureStatsById  = this.getFeatureStatsByIdFromEntityData(this._entities);
+      //console.log(`SzWhyEntityComponent._featureStatsById: `, this._featureStatsById);
+
+      this._shapedData    = this.transformData(this._data, this._entities);
+      this._formattedData = this.formatData(this._shapedData);
+      // now that we have all our "results" grab the features so we 
+      // can iterate by those and blank out cells that are missing
+      this._rows          = this.getRowsFromData(this._shapedData, this._orderedFeatureTypes);
+      this._headers       = this.getHeadersFromData(this._shapedData);
     }
     /**
      * Extends the data response from the why api with data found "rows" that can be more directly utilized by the rendering template.


### PR DESCRIPTION
# Pull request questions

## Which issue does this address

resolves #525 

## Why was change needed

the how/why/why not components wouldn't finish loading when the server doesn't respond back with the active config. 

## What does change improve

when the server doesn't respond back with the fTypes the components just ignore trying to sort the field rows by the config order and instead render in the order as provided in the api why/how response features.
