### PR TITLE
#538 options for pre-flighting the How Report

### DIFF
--- a/src/lib/entity/detail/sz-entity-detail-header/header.component.html
+++ b/src/lib/entity/detail/sz-entity-detail-header/header.component.html
@@ -21,12 +21,17 @@
       matTooltipPosition="above"
       matTooltip="Click to display this entities Why Report"
       >Why Analysis<mat-icon class="why-report-icon" fontIcon="merge_type"></mat-icon></button>
-      <button *ngIf="showHowFunction" class="detail-header-how-button" mat-stroked-button 
-      (click)="onHowButtonClickHandler($event)"
-      color="accent"
-      matTooltipPosition="above"
-      matTooltip="Click to see How this entity was resolved"
-      >How Report<mat-icon class="how-report-icon" fontIcon="insert_chart_outlined"></mat-icon></button>
+      <div *ngIf="showHowFunction"
+        matTooltipPosition="above"
+        [matTooltip]="howButtonTooltipText()"
+        [matTooltipDisabled]="!howButtonDisabled"
+      >
+        <button *ngIf="showHowFunction" class="detail-header-how-button" mat-stroked-button 
+        (click)="onHowButtonClickHandler($event)"
+        color="accent"
+        [disabled]="howButtonDisabled"
+        >How Report<mat-icon class="how-report-icon" fontIcon="insert_chart_outlined"></mat-icon></button>
+      </div>
     </div>
     <div class="detail-header__top-right">
       <div><span class="detail-header__entity-name">{{bestName | titlecase}}</span></div>

--- a/src/lib/entity/detail/sz-entity-detail-header/header.component.ts
+++ b/src/lib/entity/detail/sz-entity-detail-header/header.component.ts
@@ -372,6 +372,8 @@ export class SzEntityDetailHeaderComponent implements OnInit, OnDestroy {
   @Output() onHowButtonClick: EventEmitter<howClickEvent> = new EventEmitter<howClickEvent>();
   /** @internal */
   private _showHowFunction: boolean = false;
+  /** @internal */
+  private _howButtonDisabled: boolean = false;
   /** whether or not to show the "How button" under the entity icon */
   @Input() public set showHowFunction(value: boolean) {
     this._showHowFunction = value;
@@ -379,6 +381,17 @@ export class SzEntityDetailHeaderComponent implements OnInit, OnDestroy {
   /** whether or not the "Why button" under the entity icon is being shown*/
   public get showHowFunction(): boolean {
     return (this._showWhyFunction && this._showHowFunction) ? false : this._showHowFunction;
+  }
+  /** whether or not to disable the "How button" under the entity icon is disabled*/
+  @Input() public set howButtonDisabled(value: boolean) {
+    this._howButtonDisabled = value;
+  }
+  /** whether or not the "How button" under the entity icon is disabled */
+  public get howButtonDisabled(): boolean {
+    return this._howButtonDisabled;
+  }
+  public howButtonTooltipText(): string {
+    return this._howButtonDisabled ? "How not available. No resolution was required. " : "Click to see How this entity was resolved";
   }
   /**
    * When user clicks the "How" button this handler is invoked 

--- a/src/lib/entity/detail/sz-entity-detail.component.html
+++ b/src/lib/entity/detail/sz-entity-detail.component.html
@@ -21,6 +21,7 @@
   [forceLayout]="_forceLayout"
   [showWhyFunction]="showEntityWhyFunction"
   [showHowFunction]="showEntityHowFunction"
+  [howButtonDisabled]="howFunctionDisabled"
   (onWhyButtonClick)="this.onHeaderWhyButtonClick($event)"
   (onHowButtonClick)="this.onHeaderHowButtonClick($event)"
   [layoutClasses]="_layoutEnforcers">

--- a/src/lib/entity/detail/sz-entity-detail.component.ts
+++ b/src/lib/entity/detail/sz-entity-detail.component.ts
@@ -287,6 +287,7 @@ export class SzEntityDetailComponent implements OnInit, OnDestroy, AfterViewInit
    */
   @Input() set showHowFunctionWarnings(value: boolean) {
     this._showHowFunctionWarnings = value;
+    if(value === true) { this.dynamicHowFeatures = true; }
   }
   /** when set to true a request to the how report for the entity is made to check whether or not anything 
    * would be displayed and if the result has no steps in it's "resolutionSteps" collection when the user clicks

--- a/src/lib/entity/detail/sz-entity-detail.component.ts
+++ b/src/lib/entity/detail/sz-entity-detail.component.ts
@@ -24,6 +24,8 @@ import { parseBool } from '../../common/utils';
 import { SzDataSourceRecordsSelection, SzWhySelectionModeBehavior, SzWhySelectionMode } from '../../models/data-source-record-selection';
 import { SzMatchKeyTokenFilterScope } from '../../models/graph';
 import { howClickEvent } from '../../models/data-how';
+import { SzHowUIService } from '../../services/sz-how-ui.service';
+import { SzAlertMessageDialog } from '../../shared/alert-dialog/sz-alert-dialog.component';
 
 /**
  * The Entity Detail Component.
@@ -130,14 +132,18 @@ export class SzEntityDetailComponent implements OnInit, OnDestroy, AfterViewInit
   private _possibleMatchesSectionCollapsed: boolean = false;
   private _possibleRelationshipsSectionCollapsed: boolean = false;
   private _disclosedRelationshipsSectionCollapsed: boolean = false;
-
   // why utilities
   private _whySelectionMode: SzWhySelectionModeBehavior = SzWhySelectionMode.NONE;
-  private _showEntityHowFunction: boolean = false;
   private _showEntityWhyFunction: boolean = false;
   private _showRecordWhyUtilities: boolean = false;
   private _showRelatedWhyNotUtilities: boolean = false;
   private _openWhyComparisonModalOnClick: boolean = true;
+  // how utilities
+  private _showEntityHowFunction: boolean = false;
+  private _entityHasHowSteps: boolean = undefined;
+  private _dynamicHowFeatures: boolean = false;
+  private _showHowFunctionWarnings: boolean = false;
+  private _howFunctionDisabled: boolean = false;
   // graph utilities
   private _showGraphNodeContextMenu: boolean = false;
   private _showGraphLinkContextMenu: boolean = false;
@@ -146,8 +152,10 @@ export class SzEntityDetailComponent implements OnInit, OnDestroy, AfterViewInit
   private _headerHowButtonClicked: Subject<howClickEvent> = new Subject<howClickEvent>();
   /** (Observeable) when the user clicks on the "Why" button in header under the icon */
   public headerHowButtonClicked = this._headerHowButtonClicked.asObservable();
-  /** (Event Emitter) when the user clicks on the "Why" button in header under the icon */
-  @Output() howButtonClick      = new EventEmitter<howClickEvent>();
+  /** (Event Emitter) when the user clicks on the "How" button in header under the icon */
+  @Output() howButtonClick        = new EventEmitter<howClickEvent>();
+  /** (Event Emitter) when the how report would have no resolution steps resulting in an empty report */
+  @Output() howReportUnavailable  = new EventEmitter<boolean>();
   /** @internal */
   private _headerWhyButtonClicked: Subject<SzEntityIdentifier> = new Subject<SzEntityIdentifier>();
   /** (Observeable) when the user clicks on the "Why" button in header under the icon */
@@ -232,13 +240,60 @@ export class SzEntityDetailComponent implements OnInit, OnDestroy, AfterViewInit
   @Input() set whySelectionMode(value: SzWhySelectionModeBehavior) {
     this._whySelectionMode = value;
   }
+  /** when "dynamicHowFeatures" or "showHowFunctionWarnings" is set to true
+   * an api request to the entity's how report is made and this value is set to true.
+   */
+  @Input() set howFunctionDisabled(value: boolean) {
+    this._howFunctionDisabled = value;
+  }
+  /** when "dynamicHowFeatures" or "showHowFunctionWarnings" is set to true
+   * an api request to the entity's how report is made and this value is set to true.
+   */
+  get howFunctionDisabled(): boolean {
+    return this._howFunctionDisabled;
+  }
+  /** if the entity's how report has no resolution steps and this value is set to true the button for the 
+   * how report in the header will be disabled and will not emit the click event when the user clicks it
+   */
+  @Input() set dynamicHowFeatures(value: boolean) {
+    this._dynamicHowFeatures = value;
+  }
+  /** if the entity's how report has no resolution steps and this value is set to true the button for the 
+   * how report in the header will be disabled and will not emit the click event when the user clicks it
+   */
+  get dynamicHowFeatures(): boolean {
+    return this._dynamicHowFeatures;
+  }
   /** whether or not the "how" button for the entire entity is shown */
   public get showEntityHowFunction(): boolean {
     return this._showEntityHowFunction;
   }
   /** whether or not to show the "how" button for the entire entity */
   @Input() set showEntityHowFunction(value: boolean) {
+    if(value !== this._showEntityHowFunction && 
+      value === true && 
+      this._entityId !== undefined &&
+      (this._dynamicHowFeatures === true || 
+      this._showHowFunctionWarnings === true)
+      ) {
+        // check to see if entity has how steps, if not disable how functions
+        this.checkIfEntityHasHowSteps();
+    }
     this._showEntityHowFunction = value;
+  }
+  /** when set to true a request to the how report for the entity is made to check whether or not anything 
+   * would be displayed and if the result has no steps in it's "resolutionSteps" collection when the user clicks
+   * the how report button an alert will be displayed telling the user that the report is unavailable.
+   */
+  @Input() set showHowFunctionWarnings(value: boolean) {
+    this._showHowFunctionWarnings = value;
+  }
+  /** when set to true a request to the how report for the entity is made to check whether or not anything 
+   * would be displayed and if the result has no steps in it's "resolutionSteps" collection when the user clicks
+   * the how report button an alert will be displayed telling the user that the report is unavailable.
+   */
+  get showHowFunctionWarnings(): boolean {
+    return this._showHowFunctionWarnings;
   }
   /** whether or not the "why" comparison button for the entire entity is shown */
   public get showEntityWhyFunction(): boolean {
@@ -670,12 +725,13 @@ export class SzEntityDetailComponent implements OnInit, OnDestroy, AfterViewInit
   }
 
   constructor(
-    private searchService: SzSearchService,
-    public prefs: SzPrefsService,
     private cd: ChangeDetectorRef,
-    public overlay: Overlay,
     public dialog: MatDialog,
-    public viewContainerRef: ViewContainerRef
+    private howUIService: SzHowUIService,
+    public overlay: Overlay,
+    public prefs: SzPrefsService,
+    private searchService: SzSearchService,
+    public viewContainerRef: ViewContainerRef,
   ) {}
 
   ngOnInit() {
@@ -813,7 +869,31 @@ export class SzEntityDetailComponent implements OnInit, OnDestroy, AfterViewInit
    */
   public onHeaderHowButtonClick(event: howClickEvent){
     //console.log(`SzEntityDetailComponent.onHeaderHowButtonClick()`, event);
-    this.howButtonClick.emit(event);
+    if(this._showHowFunctionWarnings && !this._entityHasHowSteps){
+      this.dialog.open(SzAlertMessageDialog, {
+        panelClass: 'alert-dialog-panel',
+        width: '350px',
+        height: '200px',
+        data: {
+          title: 'Not Available',
+          text: 'How not available. No resolution was required.',
+          showOkButton: false,
+          buttonText: 'Close'
+        }
+      });
+    } else {
+      // do pre-flight check
+      this.checkIfEntityHasHowSteps(false).pipe(
+        takeUntil(this.unsubscribe$),
+        take(1)
+      ).subscribe((hasResults) => {
+        if(hasResults) {
+          this.howButtonClick.emit(event);
+        } else {
+          this.howReportUnavailable.emit(true);
+        }
+      })
+    }
   }
   /**
    * proxies internal "why button" header click to "onHeaderWhyButtonClick" event.
@@ -904,18 +984,28 @@ export class SzEntityDetailComponent implements OnInit, OnDestroy, AfterViewInit
 
       this.searchService.getEntityById(this._entityId, true).
       pipe(
-        tap(res => console.log('SzSearchService.getEntityById: ' + this._entityId, res))
+        tap(res => console.log('SzSearchService.getEntityById: ' + this._entityId, res)),
+        takeUntil(this.unsubscribe$),
+        take(1)
       ).
-      subscribe((entityData: SzEntityData) => {
-        // console.log('sz-entity-detail.onEntityIdChange: ', entityData);
-        this.entityDetailJSON = JSON.stringify(entityData, null, 4);
-        this.entity = entityData;
-        this.onEntityDataChanged();
-        this.requestEnd.emit( entityData );
-        this.dataChanged.next( entityData );
-      }, (err)=> {
-        this.requestEnd.emit( err );
-        this.exception.next( err );
+      subscribe({
+        next: (entityData: SzEntityData) => {
+          // console.log('sz-entity-detail.onEntityIdChange: ', entityData);
+          this.entityDetailJSON = JSON.stringify(entityData, null, 4);
+          this.entity = entityData;
+          this.onEntityDataChanged();
+          this.requestEnd.emit( entityData );
+          this.dataChanged.next( entityData );
+          if(this._showEntityHowFunction && (this._dynamicHowFeatures === true || 
+            this._showHowFunctionWarnings === true)) {
+            // check to see if entity has how steps, if not disable how functions
+            this.checkIfEntityHasHowSteps();
+          }
+        }, 
+        error: (err)=> {
+          this.requestEnd.emit( err );
+          this.exception.next( err );
+        }
       });
     }
   }
@@ -1006,6 +1096,51 @@ export class SzEntityDetailComponent implements OnInit, OnDestroy, AfterViewInit
         }
       });
     }
+  }
+  /** 
+   * when a entity id has been changed and the "" flag is set to true we run a 
+   * pre-click check to make sure that the how button returns a valid report.
+   * @internal
+  */
+  private checkIfEntityHasHowSteps(emitEvents?: boolean) {
+    let _retObs = new Subject<boolean>();
+    let retObs  = _retObs.asObservable();
+    retObs.pipe(
+      takeUntil(this.unsubscribe$),
+      take(1)
+    ).subscribe((hasHowSteps) => {
+      this._entityHasHowSteps = hasHowSteps;
+      if(emitEvents !== false) {
+        this.howReportUnavailable.emit(!hasHowSteps);
+      }
+      if(this._dynamicHowFeatures) {
+        this._howFunctionDisabled = (this._dynamicHowFeatures && !hasHowSteps);
+      }
+    })
+    if(this._entityId){
+      // check to see if entity has how steps, if not disable how functions
+      this.howUIService.getHowDataForEntity(this._entityId).pipe(
+        takeUntil(this.unsubscribe$),
+        take(1)
+      ).subscribe({
+        next: (resp)=>{
+          if(resp && resp.data && resp.data.resolutionSteps && Object.keys(resp.data.resolutionSteps).length > 0) {
+            _retObs.next(true);
+          } else {
+            _retObs.next(false);
+          }
+        },
+        error: (err) => {
+          this.exception.next( err );
+          _retObs.next(false);
+        }
+      });
+    } else {
+      setTimeout(() => {
+        _retObs.next(false);
+      }, 1000);
+    }
+    return _retObs.asObservable();
   }
 
 }

--- a/src/lib/how/cards/sz-how-virtual-entity-card.component.html
+++ b/src/lib/how/cards/sz-how-virtual-entity-card.component.html
@@ -17,7 +17,10 @@
             </ul>
         </mat-expansion-panel>
         <!-- start "other features" -->
-        <mat-expansion-panel class="feature-drawer feature-drawer-features" [expanded]="isExpanded(featBucket.name)" (opened)="onDrawerOpen(featBucket.name)" (closed)="onDrawerClose(featBucket.name)" hideToggle *ngFor="let featBucket of orderedFeatures">
+        <mat-expansion-panel class="feature-drawer feature-drawer-features" 
+        [expanded]="isExpanded(featBucket.name)" 
+        (opened)="onDrawerOpen(featBucket.name)" 
+        (closed)="onDrawerClose(featBucket.name)" hideToggle *ngFor="let featBucket of orderedFeatures">
             <mat-expansion-panel-header>
                 <mat-icon class="toggle-expansion-icon" fontIcon="arrow_right"></mat-icon>
                 {{featureName(featBucket.name)}}<span class="count-bubble">{{featureCount(featBucket.features)}}</span></mat-expansion-panel-header>

--- a/src/lib/scss/styles.scss
+++ b/src/lib/scss/styles.scss
@@ -197,6 +197,7 @@ mat-chip-listbox.match-keys {
     padding: 0px;
     overflow: hidden;
     max-height: 100vh;
+    background: none;
   }
 }
 .mat-mdc-dialog-container {

--- a/src/lib/shared/alert-dialog/sz-alert-dialog.component.html
+++ b/src/lib/shared/alert-dialog/sz-alert-dialog.component.html
@@ -1,5 +1,5 @@
-<h1 mat-dialog-title cdkDrag cdkDragRootElement=".cdk-overlay-pane" cdkDragHandle>{{data.title}}</h1>
-<div mat-dialog-content>{{data.text}}</div>
+<h1 mat-dialog-title cdkDrag cdkDragRootElement=".cdk-overlay-pane" cdkDragHandle>{{title}}</h1>
+<div mat-dialog-content>{{text}}</div>
 <div mat-dialog-actions>
-  <button mat-stroked-button mat-dialog-close="true" color="primary" class="ok">{{data.buttonText}}</button>
+  <button mat-stroked-button mat-dialog-close="true" color="primary" class="ok">{{buttonText}}</button>
 </div>


### PR DESCRIPTION
# Pull request questions

## Which issue does this address

resolves #538 

## Why was change needed

The how button would be displayed regardless of whether or not an entity's how report would be empty due to single record entities or `EXACT_MATCH` records leading to users being given empty or broken looking reports.

## What does change improve

## Added

### Properties on the entity detail component:
- `dynamicHowFeatures` when enabled will make a background request to the how api surface when the detail component is loaded to selectively either enable warning messages or disable/enable **"How"** buttons
- `howFunctionDisabled` will return true if the how related components have been disabled
- `showHowFunctionWarnings`  when set to true will display a warning message when a user clicks a **"How"** button and the associated how report would be blank .

### Events/Emitters on the entity detail component:
- `howReportUnavailable` will be emitted when the preflight request that is performed does not return any `resolutionSteps` for the how request. This event can occur on initial load of the detail component **_IF_** `dynamicHowFeatures` _OR_ `showHowFunctionWarnings` is set to `true`. Otherwise it may occur only on user-initiated event but may incur latencency between the user's event and emitting the `howReportUnavailable` event.