### PR TITLE
#574 fix for edgecase multiple final states single step

### DIFF
--- a/src/lib/how/sz-how-entity.component.ts
+++ b/src/lib/how/sz-how-entity.component.ts
@@ -652,8 +652,28 @@ export class SzHowEntityComponent implements OnInit, OnDestroy {
           retVal.push(extendedNode);
           extendedNode.virtualEntityIds = [step.resolvedVirtualEntityId];
         } else {
-          // just append to list
-          retVal.push(extendedNode);
+          if(parentIsFinal) { 
+            // this is a final step node so append it to itself for display purposes
+            let finalNode: SzResolutionStepNode = Object.assign({
+              id: step.resolvedVirtualEntityId,
+              stepType: SzResolutionStepDisplayType.FINAL,
+              itemType: SzResolutionStepListItemType.FINAL,
+              isInterim: false
+            }, step);
+            finalNode.children   = [(Object.assign({
+              id: step.resolvedVirtualEntityId,
+              stepType: stepType,
+              itemType: SzResolutionStepListItemType.STEP,
+              isInterim: false
+            }, step) as SzResolutionStepNode)]
+            .sort(sortByStepNumber);
+            //if(extendedNode.children && extendedNode.children.length > 1) { extendedNode.children = createStacksForContiguousAddRecords(extendedNode.children); }
+            finalNode.virtualEntityIds = this.getVirtualEntityIdsForNode(finalNode);
+            retVal.push(finalNode);
+          } else {
+            // just append to list
+            retVal.push(extendedNode);
+          }
         }
       });
       // sort by step number

--- a/src/lib/services/sz-how-ui.service.ts
+++ b/src/lib/services/sz-how-ui.service.ts
@@ -323,7 +323,7 @@ export class SzHowUIService {
       let typesToExclude = node.itemType === SzResolutionStepListItemType.GROUP ? [SzResolutionStepListItemType.STACK] : [];
       _stepNodes
         .filter((_s: SzResolutionStepNode) => {
-          return (_s && _s.itemType === SzResolutionStepListItemType.FINAL && _s.virtualEntityIds.indexOf(node.id) > -1);
+          return (_s && _s.itemType === SzResolutionStepListItemType.FINAL && _s.virtualEntityIds && _s.virtualEntityIds.indexOf(node.id) > -1);
         })
         .forEach(this.expandNodesContainingChild.bind(this, node.id, typesToExclude));
     }
@@ -362,7 +362,7 @@ export class SzHowUIService {
     }
     // first get final node that contains node
     let finalStepNode = _stepNodes.find((fNode)=>{
-      return fNode.virtualEntityIds.indexOf(id) > -1;
+      return fNode && fNode.virtualEntityIds && fNode.virtualEntityIds.indexOf(id) > -1;
     });
     if(finalStepNode){
       //_retVal = [finalStepNode];


### PR DESCRIPTION
# Pull request questions

## Which issue does this address

resolves #574 

## Why was change needed

when a how result had multiple final states and a second state has only a single "CREATE" step(both records singletons) there was a gap in logic resulting in an step being displayed with no parent "FINAL" step.
